### PR TITLE
fix: remplace couleurs notification

### DIFF
--- a/Client_CSS.html
+++ b/Client_CSS.html
@@ -7,8 +7,9 @@
 :root {
   --couleur-primaire: #8e44ad; /* Violet */
   --couleur-secondaire: #3498db; /* Bleu */
-  --couleur-succes: #5dade2; /* Bleu clair */
+  --couleur-succes: #3498db; /* Bleu */
   --couleur-erreur: #c0392b; /* Rouge */
+  --couleur-avertissement: #5dade2; /* Bleu clair */
   --gris-clair: #f9f9f9;
   --gris-moyen: #6c757d;
   --gris-fonce: #343a40;
@@ -109,8 +110,9 @@ body {
 
 #conteneur-notifications { position: fixed; bottom: 20px; right: 20px; z-index: 1000; }
 .notification { padding: 15px 20px; border-radius: 8px; color: white; font-weight: 500; box-shadow: 0 4px 15px rgba(0,0,0,0.1); animation: slideIn 0.5s ease-out forwards, slideOut 0.5s ease-in 4.5s forwards; opacity: 0; transform: translateX(100%); }
-.notification.succes { background-color: var(--couleur-succes); }
+.notification.succes { background-color: var(--couleur-succes); color: #000; }
 .notification.erreur { background-color: var(--couleur-erreur); }
+.notification.avertissement { background-color: var(--couleur-avertissement); color: var(--gris-fonce); }
 @keyframes slideIn { to { opacity: 1; transform: translateX(0); } }
 @keyframes slideOut { from { opacity: 1; transform: translateX(0); } to { opacity: 0; transform: translateX(100%); } }
 

--- a/snapshots/v829/Admin_CSS.html
+++ b/snapshots/v829/Admin_CSS.html
@@ -3,9 +3,9 @@
 :root {
   --couleur-primaire: #2980b9; /* Bleu Admin */
   --couleur-secondaire: #2c3e50; /* Gris Foncé Admin */
-  --couleur-succes: #27ae60;
+  --couleur-succes: #3498db;
   --couleur-erreur: #c0392b;
-  --couleur-avertissement: #f39c12;
+  --couleur-avertissement: #5dade2;
   --gris-clair: #f4f6f9;
   --gris-moyen: #7f8c8d;
   --gris-fonce: #34495e;
@@ -119,8 +119,11 @@ body {
 
 .info-remise {
   font-weight: bold;
-  color: var(--couleur-avertissement);
+  background-color: var(--couleur-avertissement);
+  color: var(--gris-fonce);
   margin-left: 5px;
+  padding: 0 4px;
+  border-radius: 4px;
 }
 
 /* --- FORMULAIRES & BOUTONS --- */
@@ -171,7 +174,7 @@ body {
 
 .btn-appliquer-remise {
   background-color: var(--couleur-avertissement);
-  color: white;
+  color: var(--gris-fonce);
 }
 
 .btn-sm {

--- a/snapshots/v829/Client_CSS.html
+++ b/snapshots/v829/Client_CSS.html
@@ -7,9 +7,9 @@
 :root {
   --couleur-primaire: #8e44ad; /* Violet */
   --couleur-secondaire: #3498db; /* Bleu */
-  --couleur-succes: #27ae60; /* Vert */
+  --couleur-succes: #3498db; /* Bleu */
   --couleur-erreur: #c0392b; /* Rouge */
-  --couleur-avertissement: #f39c12; /* Jaune */
+  --couleur-avertissement: #5dade2; /* Bleu clair */
   --gris-clair: #f9f9f9;
   --gris-moyen: #6c757d;
   --gris-fonce: #343a40;
@@ -99,8 +99,9 @@ body {
 
 #conteneur-notifications { position: fixed; bottom: 20px; right: 20px; z-index: 1000; }
 .notification { padding: 15px 20px; border-radius: 8px; color: white; font-weight: 500; box-shadow: 0 4px 15px rgba(0,0,0,0.1); animation: slideIn 0.5s ease-out forwards, slideOut 0.5s ease-in 4.5s forwards; opacity: 0; transform: translateX(100%); }
-.notification.succes { background-color: var(--couleur-succes); }
+.notification.succes { background-color: var(--couleur-succes); color: #000; }
 .notification.erreur { background-color: var(--couleur-erreur); }
+.notification.avertissement { background-color: var(--couleur-avertissement); color: var(--gris-fonce); }
 @keyframes slideIn { to { opacity: 1; transform: translateX(0); } }
 @keyframes slideOut { from { opacity: 1; transform: translateX(0); } to { opacity: 0; transform: translateX(100%); } }
 

--- a/snapshots/v829/Reservation_CSS.html
+++ b/snapshots/v829/Reservation_CSS.html
@@ -7,9 +7,9 @@
 :root {
   --couleur-primaire: #8e44ad; /* Violet */
   --couleur-secondaire: #3498db; /* Bleu */
-  --couleur-succes: #27ae60; /* Vert */
+  --couleur-succes: #3498db; /* Bleu */
   --couleur-erreur: #c0392b; /* Rouge - UTILISÉ POUR L'URGENCE */
-  --couleur-avertissement: #f39c12; /* Jaune */
+  --couleur-avertissement: #5dade2; /* Bleu clair */
   --gris-clair: #f9f9f9;
   --gris-moyen: #6c757d;
   --gris-fonce: #343a40;
@@ -148,8 +148,8 @@ body {
 .btn-primaire:not(:disabled):hover { background-color: #732d91; transform: translateY(-2px); }
 .btn-secondaire { background-color: var(--couleur-bordure); color: var(--gris-fonce); }
 .btn-secondaire:not(:disabled):hover { background-color: #dcdfe2; }
-.btn-succes { background-color: var(--couleur-succes); color: white; }
-.btn-succes:not(:disabled):hover { background-color: #218c4b; }
+.btn-succes { background-color: var(--couleur-succes); color: #000; }
+.btn-succes:not(:disabled):hover { background-color: #2c81ba; }
 .btn-icone { background: none; border: none; cursor: pointer; color: var(--couleur-primaire); font-size: 1.5em; }
 .btn-sm { padding: 8px 12px; font-size: 0.9em; }
 
@@ -281,9 +281,10 @@ input:checked + .glissiere:before { transform: translateX(22px); }
 
 #conteneur-notifications { position: fixed; bottom: 20px; right: 20px; z-index: 1000; display: flex; flex-direction: column; gap: 10px; }
 .notification { padding: 15px 20px; border-radius: 8px; color: white; font-weight: 500; box-shadow: 0 4px 15px rgba(0,0,0,0.1); animation: slideIn 0.5s ease-out forwards, slideOut 0.5s ease-in 4.5s forwards; opacity: 0; transform: translateX(100%); max-width: 320px; }
-.notification.succes { background-color: var(--couleur-succes); }
+.notification.succes { background-color: var(--couleur-succes); color: #000; }
 .notification.erreur { background-color: var(--couleur-erreur); }
 .notification.info { background-color: var(--couleur-secondaire); }
+.notification.avertissement { background-color: var(--couleur-avertissement); color: var(--gris-fonce); }
 @keyframes slideIn { to { opacity: 1; transform: translateX(0); } }
 @keyframes slideOut { from { opacity: 1; transform: translateX(0); } to { opacity: 0; transform: translateX(100%); } }
 


### PR DESCRIPTION
## Summary
- Harmonise les variables de couleurs success/avertissement sur la charte bleue
- Ajuste les notifications pour un contraste AA
- Nettoie les anciens snapshots des teintes vertes/oranges

## Testing
- `rg "#27ae60" -n`
- `rg "#f39c12" -n`
- `node -e "console.log('tests non disponibles');"`
- `clasp --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7398160488326a7ce2d1e005bef5f