### PR TITLE
fix: show visible focus outlines for admin controls

### DIFF
--- a/Admin_CSS.html
+++ b/Admin_CSS.html
@@ -142,10 +142,26 @@ body {
   transition: background-color 0.2s, transform 0.2s;
 }
 
+.btn:focus,
+.btn:focus-visible {
+  outline: 2px solid var(--bleu);
+  outline-offset: 2px;
+}
+
 .btn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
   transform: none;
+}
+
+input:focus,
+input:focus-visible,
+select:focus,
+select:focus-visible,
+a[href]:focus,
+a[href]:focus-visible {
+  outline: 2px solid var(--bleu);
+  outline-offset: 2px;
 }
 
 .btn-primaire {


### PR DESCRIPTION
## Summary
- highlight button focus state in admin
- add focus outline for input, select, and link elements

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b739b1eacc83269c56323417da3b4e