### PR TITLE
fix: escape user HTML in admin dashboard

### DIFF
--- a/Admin_JS.html
+++ b/Admin_JS.html
@@ -23,6 +23,17 @@ document.addEventListener('DOMContentLoaded', () => {
     let tousLesClients = [];
     let vueActuelle = 'date'; // NOUVEAU: pour savoir quelle vue rafraîchir ('date' ou 'toutes')
 
+    function escapeHtml(str) {
+      if (typeof str !== 'string') return '';
+      return str.replace(/[&<>"']/g, m => ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;'
+      }[m]));
+    }
+
     /**
      * Initialise le tableau de bord.
      */
@@ -144,50 +155,101 @@ document.addEventListener('DOMContentLoaded', () => {
      * Affiche les réservations.
      */
     function afficherReservations(reservations, montrerDate = false) {
-        if (!contenuReservations) return;
-        if (reservations.length === 0) {
-            contenuReservations.innerHTML = '<p>Aucune course à afficher.</p>';
-            return;
-        }
+      if (!contenuReservations) return;
+      contenuReservations.innerHTML = '';
+      if (reservations.length === 0) {
+        const p = document.createElement('p');
+        p.textContent = 'Aucune course à afficher.';
+        contenuReservations.appendChild(p);
+        return;
+      }
 
-        const groupeParClient = reservations.reduce((acc, resa) => {
-            const clientKey = `${resa.clientName} (${resa.clientEmail})`;
-            if (!acc[clientKey]) acc[clientKey] = [];
-            acc[clientKey].push(resa);
-            return acc;
-        }, {});
+      const groupeParClient = reservations.reduce((acc, resa) => {
+        const clientKey = `${resa.clientName} (${resa.clientEmail})`;
+        if (!acc[clientKey]) acc[clientKey] = [];
+        acc[clientKey].push(resa);
+        return acc;
+      }, {});
 
-        let html = '';
-        for (const nomClient in groupeParClient) {
-            html += `<div class="groupe-client"><div class="groupe-client-en-tete">${nomClient}</div>`;
-            groupeParClient[nomClient].forEach(resa => {
-                const dateDebut = new Date(resa.start);
-                const heureDebut = dateDebut.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' });
-                const dateAffichee = dateDebut.toLocaleDateString('fr-FR', { day: '2-digit', month: '2-digit', year: 'numeric' });
-                const prix = typeof resa.amount === 'number' ? resa.amount.toFixed(2) : 'N/A';
-                const infoRemiseHtml = resa.infoRemise ? `<span class="info-remise">${resa.infoRemise}</span>` : '';
-                const dateHtml = montrerDate ? `<strong>${dateAffichee}</strong> &agrave; ` : '';
-                const statutHtml = resa.statut ? `<span class="statut-badge" style="background-color: #7f8c8d; color: white; padding: 2px 6px; border-radius: 4px; font-size: 0.8em; margin-left: 8px;">${resa.statut}</span>` : '';
+      for (const nomClient in groupeParClient) {
+        const groupDiv = document.createElement('div');
+        groupDiv.className = 'groupe-client';
+        const header = document.createElement('div');
+        header.className = 'groupe-client-en-tete';
+        header.textContent = nomClient;
+        groupDiv.appendChild(header);
 
-                html += `
-                    <div class="carte-reservation">
-                        <div class="carte-heure">${dateHtml}${heureDebut}</div>
-                        <div class="carte-details">
-                            <strong>${resa.details}</strong>
-                            <small>${prix} € ${infoRemiseHtml} (~${resa.km} km) ${statutHtml}</small>
-                        </div>
-                        <div class="carte-actions">
-                            <button class="btn btn-sm btn-secondaire btn-modifier" data-id-reservation="${resa.id}">Modifier</button>
-                            <button class="btn btn-sm btn-secondaire btn-replanifier" data-id-reservation="${resa.id}">Déplacer</button>
-                            <button class="btn btn-sm btn-appliquer-remise" data-id-reservation="${resa.id}">Remise</button>
-                            <button class="btn btn-sm btn-erreur btn-supprimer" data-id-reservation="${resa.id}">Supprimer</button>
-                        </div>
-                    </div>`;
-            });
-            html += `</div>`;
-        }
-        contenuReservations.innerHTML = html;
-        attacherEcouteursActions();
+        groupeParClient[nomClient].forEach(resa => {
+          const dateDebut = new Date(resa.start);
+          const heureDebut = dateDebut.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' });
+          const dateAffichee = dateDebut.toLocaleDateString('fr-FR', { day: '2-digit', month: '2-digit', year: 'numeric' });
+          const prix = typeof resa.amount === 'number' ? resa.amount.toFixed(2) : 'N/A';
+
+          const card = document.createElement('div');
+          card.className = 'carte-reservation';
+
+          const divHeure = document.createElement('div');
+          divHeure.className = 'carte-heure';
+          if (montrerDate) {
+            const strongDate = document.createElement('strong');
+            strongDate.textContent = dateAffichee;
+            divHeure.appendChild(strongDate);
+            divHeure.appendChild(document.createTextNode(' à '));
+          }
+          divHeure.appendChild(document.createTextNode(heureDebut));
+          card.appendChild(divHeure);
+
+          const divDetails = document.createElement('div');
+          divDetails.className = 'carte-details';
+          const strong = document.createElement('strong');
+          strong.innerHTML = escapeHtml(resa.details);
+          divDetails.appendChild(strong);
+          const small = document.createElement('small');
+          small.textContent = `${prix} € (~${resa.km} km)`;
+          if (resa.infoRemise) {
+            const spanRemise = document.createElement('span');
+            spanRemise.className = 'info-remise';
+            spanRemise.innerHTML = escapeHtml(resa.infoRemise);
+            small.appendChild(document.createTextNode(' '));
+            small.appendChild(spanRemise);
+          }
+          if (resa.statut) {
+            const spanStatut = document.createElement('span');
+            spanStatut.className = 'statut-badge';
+            spanStatut.style.cssText = 'background-color: #7f8c8d; color: white; padding: 2px 6px; border-radius: 4px; font-size: 0.8em; margin-left: 8px;';
+            spanStatut.innerHTML = escapeHtml(resa.statut);
+            small.appendChild(document.createTextNode(' '));
+            small.appendChild(spanStatut);
+          }
+          divDetails.appendChild(small);
+          card.appendChild(divDetails);
+
+          const divActions = document.createElement('div');
+          divActions.className = 'carte-actions';
+          const btnModifier = document.createElement('button');
+          btnModifier.className = 'btn btn-sm btn-secondaire btn-modifier';
+          btnModifier.dataset.idReservation = resa.id;
+          btnModifier.textContent = 'Modifier';
+          const btnReplanifier = document.createElement('button');
+          btnReplanifier.className = 'btn btn-sm btn-secondaire btn-replanifier';
+          btnReplanifier.dataset.idReservation = resa.id;
+          btnReplanifier.textContent = 'Déplacer';
+          const btnRemise = document.createElement('button');
+          btnRemise.className = 'btn btn-sm btn-appliquer-remise';
+          btnRemise.dataset.idReservation = resa.id;
+          btnRemise.textContent = 'Remise';
+          const btnSupprimer = document.createElement('button');
+          btnSupprimer.className = 'btn btn-sm btn-erreur btn-supprimer';
+          btnSupprimer.dataset.idReservation = resa.id;
+          btnSupprimer.textContent = 'Supprimer';
+          divActions.append(btnModifier, btnReplanifier, btnRemise, btnSupprimer);
+          card.appendChild(divActions);
+
+          groupDiv.appendChild(card);
+        });
+        contenuReservations.appendChild(groupDiv);
+      }
+      attacherEcouteursActions();
     }
 
     /**
@@ -202,11 +264,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // --- GESTION DES MODALES (Code complet, inchangé) ---
     function ouvrirModaleAjout() {
-        const optionsClient = tousLesClients.map(c => `<option value="${c.email}">${c.nom} (${c.email})</option>`).join('');
         if (!contenuModale) return;
         contenuModale.innerHTML = `
             <h3 id="modale-titre">Ajouter une nouvelle course</h3>
-            <div class="groupe-formulaire"><label for="select-client">Client</label><select id="select-client" class="champ-formulaire"><option value="new">-- Nouveau Client --</option>${optionsClient}</select></div>
+            <div class="groupe-formulaire"><label for="select-client">Client</label><select id="select-client" class="champ-formulaire"></select></div>
             <div id="champs-client-details">
                 <div class="groupe-formulaire"><label>Email du client</label><input type="email" id="champ-email-client" class="champ-formulaire"></div>
                 <div class="groupe-formulaire"><label>Nom / Raison Sociale</label><input type="text" id="champ-nom-client" class="champ-formulaire"></div>
@@ -225,6 +286,19 @@ document.addEventListener('DOMContentLoaded', () => {
               <label><input type="checkbox" id="check-notifier"> Avertir le client</label>
               <button type="button" id="btn-confirmer-ajout" class="btn btn-primaire" disabled>Ajouter la course</button>
             </div>`;
+        const selectClient = contenuModale.querySelector('#select-client');
+        if (selectClient) {
+            const optionNew = document.createElement('option');
+            optionNew.value = 'new';
+            optionNew.textContent = '-- Nouveau Client --';
+            selectClient.appendChild(optionNew);
+            tousLesClients.forEach(c => {
+                const option = document.createElement('option');
+                option.value = c.email;
+                option.innerHTML = `${escapeHtml(c.nom)} (${escapeHtml(c.email)})`;
+                selectClient.appendChild(option);
+            });
+        }
         if (modale) modale.classList.remove('hidden');
         attacherEcouteursModaleAjout();
     }


### PR DESCRIPTION
## Summary
- add escapeHtml utility and render reservations via DOM nodes
- sanitize client options in add-reservation modal

## Testing
- `node -e "function escapeHtml(str){return str.replace(/[&<>\\"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','\\"':'&quot;','\\'':'&#39;'}[m]));} console.log(escapeHtml('<script>test</script>'));"`


------
https://chatgpt.com/codex/tasks/task_e_68b739b7c0408326a59ded926e2cade6