### PR TITLE
feat: stylise notifications admin

### DIFF
--- a/Admin_CSS.html
+++ b/Admin_CSS.html
@@ -5,6 +5,8 @@
   --couleur-secondaire: #2c3e50; /* Gris Foncé Admin */
   --couleur-erreur: #c0392b;
   --couleur-avertissement: #8e44ad; /* Violet */
+  --couleur-succes: #5dade2; /* Bleu clair */
+  --violet: #8e44ad;
   --gris-clair: #f4f6f9;
   --gris-moyen: #7f8c8d;
   --gris-fonce: #34495e;
@@ -328,7 +330,19 @@ body {
 }
 
 .notification {
-  /* Styles similaires à la page de réservation */
+  background: var(--violet);
+  color: #fff;
+  padding: 8px 12px;
+  border-radius: 8px;
+  box-shadow: var(--ombre-portee);
+}
+
+.notification.succes {
+  background-color: var(--couleur-succes);
+}
+
+.notification.erreur {
+  background-color: var(--couleur-erreur);
 }
 
 .theme-selector {


### PR DESCRIPTION
## Summary
- style admin notifications using brand palette
- add success and error notification variants

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b739c742b8832688e5f06139277878