### PR TITLE
feat: hide archived reservations in admin

### DIFF
--- a/Admin_JS.html
+++ b/Admin_JS.html
@@ -5,6 +5,8 @@
  * =================================================================
  */
 
+const ADMIN_HIDE_ARCHIVED_ENABLED = <?!= ADMIN_HIDE_ARCHIVED_ENABLED ? 'true' : 'false' ?>;
+
 document.addEventListener('DOMContentLoaded', () => {
     // --- Références aux éléments du DOM ---
     const indicateurChargement = document.getElementById('indicateur-chargement');
@@ -144,6 +146,9 @@ document.addEventListener('DOMContentLoaded', () => {
      * Affiche les réservations.
      */
     function afficherReservations(reservations, montrerDate = false) {
+        if (ADMIN_HIDE_ARCHIVED_ENABLED) {
+            reservations = reservations.filter(r => r.statut !== 'Archivée');
+        }
         if (!contenuReservations) return;
         if (reservations.length === 0) {
             contenuReservations.innerHTML = '<p>Aucune course à afficher.</p>';

--- a/Administration.gs
+++ b/Administration.gs
@@ -57,7 +57,7 @@ function obtenirToutesReservationsAdmin() {
 
     const donnees = feuille.getDataRange().getValues();
 
-    const reservations = donnees.slice(1).map(ligne => {
+    let reservations = donnees.slice(1).map(ligne => {
       try {
         // CORRECTION PRINCIPALE : On crée un objet Date complet dès le début
         const dateHeureSheet = new Date(ligne[indices["Date"]]);
@@ -122,6 +122,10 @@ function obtenirToutesReservationsAdmin() {
       }
     }).filter(Boolean);
 
+    if (ADMIN_HIDE_ARCHIVED_ENABLED) {
+      reservations = reservations.filter(r => r.statut !== 'Archivée');
+    }
+
     reservations.sort((a, b) => new Date(b.start) - new Date(a.start));
     
     return { success: true, reservations: reservations };
@@ -151,7 +155,7 @@ function obtenirToutesReservationsPourDate(dateFiltreString) {
 
     const donnees = feuille.getDataRange().getValues();
     
-    const reservations = donnees.slice(1).map(ligne => {
+    let reservations = donnees.slice(1).map(ligne => {
       // CORRECTION PRINCIPALE : On crée un objet Date complet dès le début
       const dateCell = ligne[indices["Date"]];
       if (!dateCell) return null;
@@ -223,6 +227,10 @@ function obtenirToutesReservationsPourDate(dateFiltreString) {
         return null; 
       }
     }).filter(Boolean);
+
+    if (ADMIN_HIDE_ARCHIVED_ENABLED) {
+      reservations = reservations.filter(r => r.statut !== 'Archivée');
+    }
 
     reservations.sort((a, b) => new Date(a.start) - new Date(b.start));
     return { success: true, reservations: reservations };

--- a/Configuration.gs
+++ b/Configuration.gs
@@ -52,6 +52,7 @@ const CA_EN_COURS_ENABLED = true; // Active l'affichage du CA en cours
 const SLOTS_AMPM_ENABLED = false; // Sépare les créneaux matin/après-midi
 const THEME_V2_ENABLED = false; // Active la nouvelle version du thème
 const BILLING_V2_DRYRUN = false; // Mode test pour la facturation V2 (aucune écriture)
+const ADMIN_HIDE_ARCHIVED_ENABLED = false; // Cache les réservations archivées côté admin
 
 const THEME_SELECTION_ENABLED = true; // Active le choix de thème côté client
 const THEME_DEFAULT = 'nocturne';


### PR DESCRIPTION
## Summary
- add ADMIN_HIDE_ARCHIVED_ENABLED flag
- hide archived reservations server and client side when flag enabled

## Testing
- `node -e "const vm=require('vm');const fs=require('fs');vm.runInNewContext(fs.readFileSync('Debug.gs'),'');if(typeof lancerTousLesTests==='function'){console.log(lancerTousLesTests());}}"` *(fails: The "object" argument must be of type object)*

------
https://chatgpt.com/codex/tasks/task_e_68b739ee58cc8326829fdd74ea78125d