### PR TITLE
feat: ajoute cache config

### DIFF
--- a/Administration.gs
+++ b/Administration.gs
@@ -6,6 +6,14 @@
 // =================================================================
 
 /**
+ * Invalide la configuration mise en cache.
+ * À utiliser après toute modification manuelle des paramètres.
+ */
+function invaliderCacheConfiguration() {
+  CacheService.getScriptCache().remove('CONFIG_JSON');
+}
+
+/**
  * Calcule le chiffre d'affaires du mois en cours.
  * @return {number|null} Total du CA ou null si désactivé ou non autorisé.
  */

--- a/Code.gs
+++ b/Code.gs
@@ -78,22 +78,23 @@ function doGet(e) {
     const template = HtmlService.createTemplateFromFile('Reservation_Interface');
     template.appUrl = ScriptApp.getService().getUrl();
     template.nomService = NOM_ENTREPRISE;
-    template.TARIFS_JSON = JSON.stringify(TARIFS);
-    template.DUREE_BASE = DUREE_BASE;
-    template.DUREE_ARRET_SUP = DUREE_ARRET_SUP;
-    template.KM_BASE = KM_BASE;
-    template.KM_ARRET_SUP = KM_ARRET_SUP;
-    template.URGENT_THRESHOLD_MINUTES = URGENT_THRESHOLD_MINUTES;
+    const conf = getConfigCached();
+    template.TARIFS_JSON = JSON.stringify(conf.TARIFS);
+    template.DUREE_BASE = conf.DUREE_BASE;
+    template.DUREE_ARRET_SUP = conf.DUREE_ARRET_SUP;
+    template.KM_BASE = conf.KM_BASE;
+    template.KM_ARRET_SUP = conf.KM_ARRET_SUP;
+    template.URGENT_THRESHOLD_MINUTES = conf.URGENT_THRESHOLD_MINUTES;
     template.dateDuJour = Utilities.formatDate(new Date(), Session.getScriptTimeZone(), "yyyy-MM-dd");
 
     // NOUVEAU : Ajout des variables pour la bannière d'information
-    template.heureDebut = HEURE_DEBUT_SERVICE;
-    template.heureFin = HEURE_FIN_SERVICE;
+    template.heureDebut = conf.HEURE_DEBUT_SERVICE;
+    template.heureFin = conf.HEURE_FIN_SERVICE;
     // Tarifs de base pour la bannière d'information
-    template.prixBaseNormal = (TARIFS && TARIFS['Normal']) ? TARIFS['Normal'].base : '';
-    template.prixBaseSamedi = (TARIFS && TARIFS['Samedi']) ? TARIFS['Samedi'].base : '';
-    template.prixBaseUrgent = (TARIFS && TARIFS['Urgent']) ? TARIFS['Urgent'].base : '';
-    template.tvaApplicable = typeof TVA_APPLICABLE !== 'undefined' ? TVA_APPLICABLE : false;
+    template.prixBaseNormal = (conf.TARIFS && conf.TARIFS['Normal']) ? conf.TARIFS['Normal'].base : '';
+    template.prixBaseSamedi = (conf.TARIFS && conf.TARIFS['Samedi']) ? conf.TARIFS['Samedi'].base : '';
+    template.prixBaseUrgent = (conf.TARIFS && conf.TARIFS['Urgent']) ? conf.TARIFS['Urgent'].base : '';
+    template.tvaApplicable = typeof conf.TVA_APPLICABLE !== 'undefined' ? conf.TVA_APPLICABLE : false;
 
 
     return template.evaluate()

--- a/Configuration.gs
+++ b/Configuration.gs
@@ -43,6 +43,7 @@ const KM_BASE = 9;
 const KM_ARRET_SUP = 3;
 
 // --- Flags d'activation ---
+const CONFIG_CACHE_ENABLED = false; // Active le cache de configuration
 const CALENDAR_RESYNC_ENABLED = true; // Permet de resynchroniser les événements supprimés
 const CALENDAR_PURGE_ENABLED = true; // Permet de purger les Event ID introuvables
 const BILLING_MULTI_SHEET_ENABLED = true; // Agrège toutes les feuilles "Facturation*"
@@ -93,4 +94,28 @@ const COLONNE_TYPE_REMISE_CLIENT = "Type de Remise";
 const COLONNE_VALEUR_REMISE_CLIENT = "Valeur Remise";
 const COLONNE_NB_TOURNEES_OFFERTES = "Nombre Tournées Offertes";
 
+
+function getConfig() {
+  return {
+    TARIFS: TARIFS,
+    DUREE_BASE: DUREE_BASE,
+    DUREE_ARRET_SUP: DUREE_ARRET_SUP,
+    KM_BASE: KM_BASE,
+    KM_ARRET_SUP: KM_ARRET_SUP,
+    URGENT_THRESHOLD_MINUTES: URGENT_THRESHOLD_MINUTES,
+    HEURE_DEBUT_SERVICE: HEURE_DEBUT_SERVICE,
+    HEURE_FIN_SERVICE: HEURE_FIN_SERVICE,
+    TVA_APPLICABLE: typeof TVA_APPLICABLE !== 'undefined' ? TVA_APPLICABLE : false
+  };
+}
+
+function getConfigCached() {
+  if (!CONFIG_CACHE_ENABLED) return getConfig();
+  const cache = CacheService.getScriptCache();
+  const raw = cache.get('CONFIG_JSON');
+  if (raw) return JSON.parse(raw);
+  const conf = getConfig();
+  cache.put('CONFIG_JSON', JSON.stringify(conf), 600); // 10 min
+  return conf;
+}
 

--- a/Debug.gs
+++ b/Debug.gs
@@ -25,8 +25,9 @@ const ADMIN_TEST_EMAIL = ADMIN_EMAIL; // Utilise l'email admin de la configurati
  */
 function lancerTousLesTests() {
   Logger.log("===== DÉBUT DE LA SUITE DE TESTS COMPLÈTE =====");
-  
+
   testerValidationConfiguration();
+  testerCacheConfiguration();
   testerUtilitaires();
   testerFeuilleCalcul();
   testerCalendrier();
@@ -52,6 +53,18 @@ function testerValidationConfiguration() {
   } catch (e) {
     Logger.log(`FAILURE: validerConfiguration() a échoué. Erreur: ${e.message}`);
   }
+}
+
+function testerCacheConfiguration() {
+  Logger.log("\n--- Test de getConfigCached() ---");
+  CacheService.getScriptCache().remove('CONFIG_JSON');
+  const conf1 = getConfigCached();
+  const conf2 = getConfigCached();
+  Logger.log(`Premier appel TARIFS.Normal.base=${conf1.TARIFS.Normal.base}`);
+  Logger.log(`Deuxième appel (cache) TARIFS.Normal.base=${conf2.TARIFS.Normal.base}`);
+  CacheService.getScriptCache().remove('CONFIG_JSON');
+  const conf3 = getConfigCached();
+  Logger.log(`Après invalidation TARIFS.Normal.base=${conf3.TARIFS.Normal.base}`);
 }
 
 function testerUtilitaires() {


### PR DESCRIPTION
## Summary
- add CONFIG_CACHE_ENABLED flag and implement config caching helper
- consume cached configuration in main web app rendering
- expose admin helper to invalidate cached configuration and test coverage in debug suite

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b750075e2c83269bb89e6f538bf5fb