### PR TITLE
ci: add clasp push workflow

### DIFF
--- a/.github/workflows/clasp.yml
+++ b/.github/workflows/clasp.yml
@@ -1,0 +1,30 @@
+name: Clasp Push
+
+on:
+  workflow_dispatch:
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install Clasp
+        run: npm install -g @google/clasp
+      - name: Authenticate and Push
+        env:
+          CLASP_CREDENTIALS: ${{ secrets.CLASP_CREDENTIALS }}
+          GAS_SCRIPT_ID: ${{ secrets.GAS_SCRIPT_ID }}
+        run: |
+          printf '%s' "$CLASP_CREDENTIALS" > creds.json
+          clasp login --creds creds.json
+          cat <<EOF > .clasp.json
+          {
+            "scriptId": "$GAS_SCRIPT_ID",
+            "rootDir": "./",
+            "fileExtension": "gs"
+          }
+          EOF
+          clasp push -f

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ See `AGENTS.md` for project structure, coding style, testing steps, and the pull
 - `clasp open`: Open the Apps Script project in the browser.
 - `clasp push -f`: Push local code to Apps Script (force overwrite).
 
+## CI/CD
+Le dépôt fournit un workflow GitHub Actions (`.github/workflows/clasp.yml`) qui exécute `clasp push -f` à l'aide de secrets `CLASP_CREDENTIALS` et `GAS_SCRIPT_ID`.
+
+### Reprise manuelle
+1. Exécuter `./clasp-helper.cmd` puis choisir **Push**, ou se connecter via `npx @google/clasp login --creds <fichier>`.
+2. Lancer `npx @google/clasp push -f`.
+3. En cas de conflit, exécuter `npx @google/clasp pull` avant de retenter.
+
 ## Sélecteur de thème
 1. Activer `THEME_SELECTION_ENABLED` dans `Configuration.gs`.
 2. `clasp push -f` puis créer une nouvelle version pour déploiement.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to push code via `clasp`
- document workflow and recovery steps in README

## Testing
- `npx @google/clasp pull 2>&1 | head -n 20`
- `npx @google/clasp push -f 2>&1 | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b750c791608326b65cfdc08fbdd25c