### PR TITLE
ci: secure clasp push workflow

### DIFF
--- a/.github/workflows/clasp.yml
+++ b/.github/workflows/clasp.yml
@@ -16,15 +16,16 @@ jobs:
       - name: Authenticate and Push
         env:
           CLASP_CREDENTIALS: ${{ secrets.CLASP_CREDENTIALS }}
-          GAS_SCRIPT_ID: ${{ secrets.GAS_SCRIPT_ID }}
+          CLASP_SCRIPT_ID: ${{ secrets.CLASP_SCRIPT_ID }}
         run: |
           printf '%s' "$CLASP_CREDENTIALS" > creds.json
           clasp login --creds creds.json
           cat <<EOF > .clasp.json
           {
-            "scriptId": "$GAS_SCRIPT_ID",
+            "scriptId": "$CLASP_SCRIPT_ID",
             "rootDir": "./",
             "fileExtension": "gs"
           }
           EOF
           clasp push -f
+          rm -f creds.json .clasp.json

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ See `AGENTS.md` for project structure, coding style, testing steps, and the pull
 - `clasp push -f`: Push local code to Apps Script (force overwrite).
 
 ## CI/CD
-Le dépôt fournit un workflow GitHub Actions (`.github/workflows/clasp.yml`) qui exécute `clasp push -f` à l'aide de secrets `CLASP_CREDENTIALS` et `GAS_SCRIPT_ID`.
+ Le dépôt fournit un workflow GitHub Actions (`.github/workflows/clasp.yml`) qui exécute `clasp push -f` à l'aide des secrets `CLASP_CREDENTIALS` et `CLASP_SCRIPT_ID`.
 
 ### Reprise manuelle
 1. Exécuter `./clasp-helper.cmd` puis choisir **Push**, ou se connecter via `npx @google/clasp login --creds <fichier>`.


### PR DESCRIPTION
## Summary
- ensure Clasp GitHub Action uses encrypted script id and deletes temporary credentials after pushing
- document manual recovery and secret names in README

## Testing
- `clasp --version`
- `clasp pull` *(fails: No credentials found)*
- `clasp push -f` *(fails: No credentials found)*

------
https://chatgpt.com/codex/tasks/task_e_68b75371f0b48326be108130e59ba159