### PR TITLE
fix: define header and main landmarks in reservation interface

### DIFF
--- a/Reservation_Interface.html
+++ b/Reservation_Interface.html
@@ -34,7 +34,7 @@
 
   <div id="app-conteneur-principal">
     
-    <header class="app-en-tete">
+    <header class="app-en-tete" role="banner" aria-label="En-tête de la page de réservation">
         <?!= include('Logo'); ?>
         <p>Système de réservation de tournées</p>
         <div id="banniere-client-reconnu" class="hidden">
@@ -124,7 +124,7 @@
       })();
     </script>
 
-    <main id="app-conteneur">
+    <main id="app-conteneur" role="main" aria-label="Contenu principal de la page de réservation">
       <div id="vue-calendrier" role="application" aria-roledescription="calendrier interactif" class="carte">
         <div class="carte-en-tete">
           <button id="btn-mois-precedent" class="btn-icone" aria-label="Mois précédent">&#9664;</button>


### PR DESCRIPTION
## Summary
- add banner role with aria-label to reservation header
- mark main container with main role and aria-label

## Testing
- `node -e "const fs=require('fs'); const html=fs.readFileSync('Reservation_Interface.html','utf8'); console.log('header role banner:', /<header[^>]*role=\\"banner\\"[^>]*aria-label=/i.test(html)); console.log('main role main:', /<main[^>]*role=\\"main\\"[^>]*aria-label=/i.test(html));"`
- `npx -y pa11y file://$(pwd)/Reservation_Interface.html` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b750c99cb88326b74d41634136e6ab