### PR TITLE
feat: centralize logging with helpers and request log flag

### DIFF
--- a/Admin_JS.html
+++ b/Admin_JS.html
@@ -5,6 +5,22 @@
  * =================================================================
  */
 
+/**
+ * Journalise un avertissement avec le préfixe [ELS].
+ * @param {...*} args Contenu à journaliser.
+ */
+function logWarn(...args) {
+  console.warn('[ELS]', ...args);
+}
+
+/**
+ * Journalise une erreur avec le préfixe [ELS].
+ * @param {...*} args Contenu à journaliser.
+ */
+function logError(...args) {
+  console.error('[ELS]', ...args);
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     // --- Références aux éléments du DOM ---
     const indicateurChargement = document.getElementById('indicateur-chargement');
@@ -474,7 +490,7 @@ document.addEventListener('DOMContentLoaded', () => {
         basculerIndicateurChargement(false);
         const message = typeof erreur === 'object' && erreur.message ? erreur.message : String(erreur);
         afficherNotification(`Erreur : ${message}`, "erreur");
-        console.error(erreur);
+        logError(erreur);
     }
 
     // --- Point de départ ---

--- a/Client_JS.html
+++ b/Client_JS.html
@@ -8,6 +8,22 @@
  * modification.
  */
 
+/**
+ * Journalise un avertissement avec le préfixe [ELS].
+ * @param {...*} args Contenu à journaliser.
+ */
+function logWarn(...args) {
+  console.warn('[ELS]', ...args);
+}
+
+/**
+ * Journalise une erreur avec le préfixe [ELS].
+ * @param {...*} args Contenu à journaliser.
+ */
+function logError(...args) {
+  console.error('[ELS]', ...args);
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     // --- Références aux éléments du DOM ---
     const indicateurChargement = document.getElementById('indicateur-chargement');
@@ -103,7 +119,7 @@ document.addEventListener('DOMContentLoaded', () => {
                                 caDiv.textContent = `CA en cours\u00A0: ${total.toFixed(2)}\u00A0€`;
                             }
                         })
-                        .withFailureHandler(err => console.error(err))
+                        .withFailureHandler(err => logError(err))
                         .calculerCAEnCoursClient(email);
                 } else {
                     afficherErreur(reponse.error);
@@ -378,7 +394,7 @@ document.addEventListener('DOMContentLoaded', () => {
         basculerIndicateurChargement(false);
         const message = typeof erreur === 'object' && erreur.message ? erreur.message : String(erreur);
         afficherNotification(`Erreur : ${message}`, "erreur");
-        console.error(erreur);
+        logError(erreur);
     }
 
     initialiser();

--- a/Code.gs
+++ b/Code.gs
@@ -40,6 +40,17 @@ function onOpen() {
 }
 
 /**
+ * Journalise la requête entrante.
+ * @param {Object} e L'objet d'événement de la requête.
+ */
+function logRequest(e) {
+  const dateIso = new Date().toISOString();
+  const route = e && e.parameter && e.parameter.page ? e.parameter.page : '';
+  const ua = e && e.headers ? e.headers['User-Agent'] : '';
+  Logger.log(`[Request] ${dateIso} route=${route} ua=${ua}`);
+}
+
+/**
  * S'exécute lorsqu'un utilisateur accède à l'URL de l'application web.
  * Fait office de routeur pour afficher la bonne page.
  * @param {Object} e L'objet d'événement de la requête.
@@ -47,6 +58,9 @@ function onOpen() {
  */
 function doGet(e) {
   try {
+    if (REQUEST_LOGGING_ENABLED) {
+      logRequest(e);
+    }
     // validerConfiguration(); // Assurez-vous que cette fonction existe ou commentez-la si non utilisée
 
     // Routeur de page

--- a/Configuration.gs
+++ b/Configuration.gs
@@ -52,6 +52,7 @@ const CA_EN_COURS_ENABLED = true; // Active l'affichage du CA en cours
 const SLOTS_AMPM_ENABLED = false; // Sépare les créneaux matin/après-midi
 const THEME_V2_ENABLED = false; // Active la nouvelle version du thème
 const BILLING_V2_DRYRUN = false; // Mode test pour la facturation V2 (aucune écriture)
+const REQUEST_LOGGING_ENABLED = false; // Active la journalisation des requêtes
 
 const THEME_SELECTION_ENABLED = true; // Active le choix de thème côté client
 const THEME_DEFAULT = 'nocturne';

--- a/Reservation_JS_UI.html
+++ b/Reservation_JS_UI.html
@@ -3,10 +3,26 @@
  * =================================================================
  * MODULE JAVASCRIPT - INTERFACE UTILISATEUR (UI)
  * =================================================================
- * Description: Gère les composants d'interface utilisateur génériques 
- * comme les notifications, les messages d'erreur et 
+ * Description: Gère les composants d'interface utilisateur génériques
+ * comme les notifications, les messages d'erreur et
  * l'indicateur de chargement.
  */
+
+/**
+ * Journalise un avertissement avec le préfixe [ELS].
+ * @param {...*} args Contenu à journaliser.
+ */
+function logWarn(...args) {
+  console.warn('[ELS]', ...args);
+}
+
+/**
+ * Journalise une erreur avec le préfixe [ELS].
+ * @param {...*} args Contenu à journaliser.
+ */
+function logError(...args) {
+  console.error('[ELS]', ...args);
+}
 
 /**
  * Affiche une notification animée à l'écran.
@@ -16,7 +32,7 @@
 function afficherNotification(message, type = "info") {
   const conteneur = document.getElementById('conteneur-notifications');
   if (!conteneur) {
-    console.error("Le conteneur de notifications est introuvable.");
+    logError("Le conteneur de notifications est introuvable.");
     return;
   }
   const notification = document.createElement('div');
@@ -41,7 +57,7 @@ function basculerIndicateurChargement(afficher) {
   if (indicateur) {
     indicateur.classList.toggle('hidden', !afficher);
   } else {
-    console.warn("L'élément 'indicateur-chargement' est introuvable dans le DOM.");
+    logWarn("L'élément 'indicateur-chargement' est introuvable dans le DOM.");
   }
 }
 
@@ -53,7 +69,7 @@ function afficherErreur(erreur) {
   basculerIndicateurChargement(false); // Toujours masquer le chargement en cas d'erreur.
   const messageErreur = typeof erreur === 'object' && erreur.message ? erreur.message : String(erreur);
   afficherNotification(`Erreur : ${messageErreur}`, "erreur");
-  console.error(erreur);
+  logError(erreur);
 }
 </script>
 


### PR DESCRIPTION
## Summary
- add logWarn and logError helpers for UI scripts
- replace direct console calls with helpers
- log incoming requests in Code.gs guarded by REQUEST_LOGGING_ENABLED flag

## Testing
- `rg "console\." -n`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b750cd755c832696b279656b31e3d2