### PR TITLE
fix: pin clasp 2.5.0

### DIFF
--- a/.github/workflows/clasp.yml
+++ b/.github/workflows/clasp.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           node-version: 20
       - name: Install Clasp
-        run: npm install -g @google/clasp
+        run: npm install -g @google/clasp@2.5.0
       - name: Authenticate and Push
         env:
           CLASP_CREDENTIALS: ${{ secrets.CLASP_CREDENTIALS }}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ See `AGENTS.md` for project structure, coding style, testing steps, and the pull
 - `clasp open`: Open the Apps Script project in the browser.
 - `clasp push -f`: Push local code to Apps Script (force overwrite).
 
+## Clasp Version
+Le projet utilise `@google/clasp` version `2.5.0` en local comme en CI.
+
+- Installation locale : `npm install -g @google/clasp@2.5.0`.
+- Vérifier la version : `clasp -v` (doit retourner `2.5.0`).
+- Le workflow GitHub Actions (`.github/workflows/clasp.yml`) installe la même version.
+
+### Mettre à jour
+1. Modifier `.github/workflows/clasp.yml` avec la nouvelle version.
+2. Exécuter `npm install -g @google/clasp@<nouvelle_version>` sur chaque poste.
+3. Mettre à jour cette section du README.
+
 ## CI/CD
  Le dépôt fournit un workflow GitHub Actions (`.github/workflows/clasp.yml`) qui exécute `clasp push -f` à l'aide des secrets `CLASP_CREDENTIALS` et `CLASP_SCRIPT_ID`.
 


### PR DESCRIPTION
## Summary
- pin `@google/clasp` to version 2.5.0 in GitHub Actions workflow
- document pinned Clasp version, verification step, and upgrade steps for developers

## Testing
- `npm install -g @google/clasp@2.5.0`
- `clasp -v`


------
https://chatgpt.com/codex/tasks/task_e_68b76105db4c8326bafe92862c8700bc