### PR TITLE
feat: add POST routing with logging

### DIFF
--- a/Configuration.gs
+++ b/Configuration.gs
@@ -56,6 +56,7 @@ const SLOTS_AMPM_ENABLED = false; // Sépare les créneaux matin/après-midi
 const THEME_V2_ENABLED = false; // Active la nouvelle version du thème
 const BILLING_V2_DRYRUN = false; // Mode test pour la facturation V2 (aucune écriture)
 const REQUEST_LOGGING_ENABLED = false; // Active la journalisation des requêtes
+const POST_ENDPOINT_ENABLED = false; // Active le traitement des requêtes POST
 
 const PRIVACY_LINK_ENABLED = false; // Affiche le lien Infos & confidentialité
 


### PR DESCRIPTION
## Summary
- handle POST requests via new doPost with optional JSON action routing
- add POST_ENDPOINT_ENABLED flag to control POST handling

## Testing
- `curl -X POST http://localhost:8080 -d '{"action":"getConfiguration"}'` *(fails: Couldn't connect to server)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b7d809841c8326ac809ba6999759a8