### PR TITLE
fix: centralise sheet references

### DIFF
--- a/Admin_Archive.gs
+++ b/Admin_Archive.gs
@@ -12,7 +12,7 @@ function archiverFacturesDuMois() {
     const finMoisPrecedent = new Date(debutMoisCourant.getTime() - 24 * 60 * 60 * 1000);
 
     const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
-    const feuille = ss.getSheetByName('Facturation');
+    const feuille = ss.getSheetByName(SHEET_FACTURATION);
     if (!feuille) throw new Error("La feuille 'Facturation' est introuvable.");
     const lastCol = feuille.getLastColumn();
     const header = feuille.getRange(1, 1, 1, lastCol).getValues()[0].map(v => String(v).trim());

--- a/Administration.gs
+++ b/Administration.gs
@@ -25,7 +25,7 @@ function calculerCAEnCours() {
     return null;
   }
 
-  const feuille = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName("Facturation");
+  const feuille = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName(SHEET_FACTURATION);
   if (!feuille) return null;
 
   const indices = obtenirIndicesEnTetes(feuille, ["Date", "Montant"]);
@@ -57,7 +57,7 @@ function obtenirToutesReservationsAdmin() {
       return { success: false, error: "Accès non autorisé." };
     }
 
-    const feuille = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName("Facturation");
+    const feuille = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName(SHEET_FACTURATION);
     if (!feuille) throw new Error("La feuille 'Facturation' est introuvable.");
 
     const enTetesRequis = ["Date", "Client (Email)", "Event ID", "Détails", "Client (Raison S. Client)", "ID Réservation", "Montant", "Type Remise Appliquée", "Valeur Remise Appliquée", "Tournée Offerte Appliquée", "Statut"];
@@ -151,7 +151,7 @@ function obtenirToutesReservationsPourDate(dateFiltreString) {
       return { success: false, error: "Accès non autorisé." };
     }
 
-    const feuille = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName("Facturation");
+    const feuille = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName(SHEET_FACTURATION);
     if (!feuille) throw new Error("La feuille 'Facturation' est introuvable.");
 
     const enTetesRequis = ["Date", "Client (Email)", "Event ID", "Détails", "Client (Raison S. Client)", "ID Réservation", "Montant", "Type Remise Appliquée", "Valeur Remise Appliquée", "Tournée Offerte Appliquée", "Statut"];
@@ -250,7 +250,7 @@ function obtenirToutesReservationsPourDate(dateFiltreString) {
  */
 function obtenirTousLesClients() {
     try {
-        const feuilleClients = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName("Clients");
+        const feuilleClients = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName(SHEET_CLIENTS);
         if (!feuilleClients) return [];
         const indices = obtenirIndicesEnTetes(feuilleClients, ["Email", "Raison Sociale", "Adresse", "SIRET", COLONNE_TYPE_REMISE_CLIENT, COLONNE_VALEUR_REMISE_CLIENT, COLONNE_NB_TOURNEES_OFFERTES]);
         const donnees = feuilleClients.getDataRange().getValues();
@@ -381,7 +381,7 @@ function supprimerReservation(idReservation) {
       return { success: false, error: "Accès non autorisé." };
     }
 
-    const feuilleFacturation = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName("Facturation");
+    const feuilleFacturation = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName(SHEET_FACTURATION);
     if (!feuilleFacturation) throw new Error("La feuille 'Facturation' est introuvable.");
 
     const enTete = feuilleFacturation.getRange(1, 1, 1, feuilleFacturation.getLastColumn()).getValues()[0];
@@ -434,9 +434,9 @@ function genererFactures() {
     logAdminAction("Génération Factures", "Démarrée");
 
     const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
-    const feuilleFacturation = ss.getSheetByName("Facturation");
-    const feuilleClients = ss.getSheetByName("Clients");
-    const feuilleParams = ss.getSheetByName("Paramètres");
+    const feuilleFacturation = ss.getSheetByName(SHEET_FACTURATION);
+    const feuilleClients = ss.getSheetByName(SHEET_CLIENTS);
+    const feuilleParams = ss.getSheetByName(SHEET_PARAMETRES);
 
     if (!feuilleFacturation || !feuilleClients || !feuilleParams) {
       throw new Error("Une des feuilles requises ('Facturation', 'Clients', 'Paramètres') est introuvable.");
@@ -610,7 +610,7 @@ function envoyerFacturesControlees() {
   const ui = SpreadsheetApp.getUi();
   try {
     const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
-    const feuille = ss.getSheetByName('Facturation');
+    const feuille = ss.getSheetByName(SHEET_FACTURATION);
     if (!feuille) throw new Error("La feuille 'Facturation' est introuvable.");
 
     const lastCol = feuille.getLastColumn();
@@ -643,7 +643,7 @@ function archiverFacturesDuMois() {
     const finMoisPrecedent = new Date(debutMoisCourant.getTime() - 24 * 60 * 60 * 1000);
 
     const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
-    const feuille = ss.getSheetByName('Facturation');
+    const feuille = ss.getSheetByName(SHEET_FACTURATION);
     if (!feuille) throw new Error("La feuille 'Facturation' est introuvable.");
 
     const header = feuille.getRange(1, 1, 1, feuille.getLastColumn()).getValues()[0].map(v => String(v).trim());

--- a/Configuration.gs
+++ b/Configuration.gs
@@ -27,6 +27,22 @@ const ID_MODELE_FACTURE = "1KWDS0gmyK3qrYWJd01vGID5fBVK10xlmErjgr7lrwmU";
 const ID_DOSSIER_ARCHIVES = "1UavaEsq6TkDw1QzJZ91geKyF7hrQY4S8";
 const ID_DOSSIER_TEMPORAIRE = "1yDBSzTqwaUt-abT0s7Z033C2WlN1NSs6";
 
+// --- Noms des feuilles ---
+/** Feuille contenant les données de facturation. */
+const SHEET_FACTURATION = 'Facturation';
+/** Feuille listant les clients. */
+const SHEET_CLIENTS = 'Clients';
+/** Feuille stockant les paramètres globaux. */
+const SHEET_PARAMETRES = 'Paramètres';
+/** Feuille de journalisation pour l'administration. */
+const SHEET_ADMIN_LOGS = 'Admin_Logs';
+/** Feuille de journalisation générale. */
+const SHEET_LOGS = 'Logs';
+/** Feuille des plages horaires bloquées. */
+const SHEET_PLAGES_BLOQUEES = 'Plages_Bloquees';
+/** Feuille par défaut des nouveaux classeurs. */
+const SHEET_DEFAULT = 'Sheet1';
+
 // --- Horaires & Tampons ---
 const HEURE_DEBUT_SERVICE = "08:30";
 const HEURE_FIN_SERVICE = "18:30";

--- a/FeuilleCalcul.gs
+++ b/FeuilleCalcul.gs
@@ -12,7 +12,7 @@
 function enregistrerOuMajClient(donneesClient) {
   try {
     if (!donneesClient || !donneesClient.email) return;
-    const feuilleClients = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName("Clients");
+    const feuilleClients = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName(SHEET_CLIENTS);
     if (!feuilleClients) throw new Error("La feuille 'Clients' est introuvable.");
 
     const enTetesRequis = ["Email", "Raison Sociale", "Adresse", "SIRET", COLONNE_TYPE_REMISE_CLIENT, COLONNE_VALEUR_REMISE_CLIENT, COLONNE_NB_TOURNEES_OFFERTES];
@@ -53,7 +53,7 @@ function enregistrerOuMajClient(donneesClient) {
  */
 function obtenirInfosClientParEmail(email) {
   try {
-    const feuilleClients = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName("Clients");
+    const feuilleClients = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName(SHEET_CLIENTS);
     if (!feuilleClients) return null;
 
     const enTetesRequis = ["Email", "Raison Sociale", "Adresse", "SIRET", COLONNE_TYPE_REMISE_CLIENT, COLONNE_VALEUR_REMISE_CLIENT, COLONNE_NB_TOURNEES_OFFERTES];
@@ -88,7 +88,7 @@ function decrementerTourneesOffertesClient(emailClient) {
   const lock = LockService.getScriptLock();
   if (!lock.tryLock(10000)) return;
   try {
-    const feuilleClients = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName("Clients");
+    const feuilleClients = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName(SHEET_CLIENTS);
     if (!feuilleClients) throw new Error("La feuille 'Clients' est introuvable.");
 
     const enTetesRequis = ["Email", COLONNE_NB_TOURNEES_OFFERTES];
@@ -127,7 +127,7 @@ function decrementerTourneesOffertesClient(emailClient) {
  */
 function enregistrerReservationPourFacturation(dateHeureDebut, nomClient, emailClient, type, details, montant, idEvenement, idReservation, note, tourneeOfferteAppliquee = false, typeRemiseAppliquee = '', valeurRemiseAppliquee = 0) {
   try {
-    const feuilleFacturation = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName("Facturation");
+    const feuilleFacturation = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName(SHEET_FACTURATION);
     if (!feuilleFacturation) throw new Error("La feuille 'Facturation' est introuvable.");
 
     const enTetesRequis = ["Date", "Client (Raison S. Client)", "Client (Email)", "Type", "Détails", "Montant", "Statut", "Valider", "N° Facture", "Event ID", "ID Réservation", "Note Interne", "Tournée Offerte Appliquée", "Type Remise Appliquée", "Valeur Remise Appliquée", "Lien Note"];
@@ -165,7 +165,7 @@ function enregistrerReservationPourFacturation(dateHeureDebut, nomClient, emailC
  */
 function obtenirPlagesBloqueesPourDate(date) {
     try {
-        const feuillePlagesBloquees = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName("Plages_Bloquees");
+        const feuillePlagesBloquees = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName(SHEET_PLAGES_BLOQUEES);
         if (!feuillePlagesBloquees) return [];
 
         const indices = obtenirIndicesEnTetes(feuillePlagesBloquees, ["Date", "Heure_Debut", "Heure_Fin"]);

--- a/Gestion.gs
+++ b/Gestion.gs
@@ -35,7 +35,7 @@ function validerClientParEmail(emailClient) {
  */
 function obtenirReservationsClient(emailClient) {
   try {
-    const feuille = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName("Facturation");
+    const feuille = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName(SHEET_FACTURATION);
     const indices = obtenirIndicesEnTetes(feuille, ["Date", "Client (Email)", "Event ID", "Détails", "Client (Raison S. Client)", "ID Réservation", "Montant"]);
     
     const donnees = feuille.getDataRange().getValues();
@@ -114,7 +114,7 @@ function calculerCAEnCoursClient(emailClient) {
     if (!CA_EN_COURS_ENABLED) return 0;
     if (!emailClient) return 0;
 
-    const feuille = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName('Facturation');
+    const feuille = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName(SHEET_FACTURATION);
     if (!feuille) return 0;
     const indices = obtenirIndicesEnTetes(feuille, ['Date', 'Client (Email)', 'Montant']);
     const lignes = feuille.getDataRange().getValues();
@@ -147,7 +147,7 @@ function obtenirFacturesPourClient(emailClient) {
     const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
     const feuilles = BILLING_MULTI_SHEET_ENABLED
       ? ss.getSheets().filter(f => f.getName().startsWith('Facturation'))
-      : [ss.getSheetByName('Facturation')];
+      : [ss.getSheetByName(SHEET_FACTURATION)];
     if (!feuilles.length || feuilles.some(f => !f)) throw new Error("La feuille 'Facturation' est introuvable.");
     const factures = [];
     feuilles.forEach(feuille => {
@@ -196,7 +196,7 @@ function envoyerFactureClient(emailClient, numeroFacture) {
     const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
     const feuilles = BILLING_MULTI_SHEET_ENABLED
       ? ss.getSheets().filter(f => f.getName().startsWith('Facturation'))
-      : [ss.getSheetByName('Facturation')];
+      : [ss.getSheetByName(SHEET_FACTURATION)];
     if (!feuilles.length || feuilles.some(f => !f)) throw new Error("La feuille 'Facturation' est introuvable.");
     let row = null;
     let idx = null;
@@ -243,7 +243,7 @@ function mettreAJourDetailsReservation(idReservation, nouveauxArrets) {
   if (!lock.tryLock(30000)) return { success: false, error: "Le système est occupé, veuillez réessayer." };
 
   try {
-    const feuille = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName("Facturation");
+    const feuille = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName(SHEET_FACTURATION);
     const enTete = feuille.getRange(1, 1, 1, feuille.getLastColumn()).getValues()[0];
     const indices = {
       idResa: enTete.indexOf("ID Réservation"), idEvent: enTete.indexOf("Event ID"),
@@ -319,7 +319,7 @@ function replanifierReservation(idReservation, nouvelleDate, nouvelleHeure) {
   if (!lock.tryLock(30000)) return { success: false, error: "Le système est occupé." };
 
   try {
-    const feuille = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName("Facturation");
+    const feuille = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName(SHEET_FACTURATION);
     const enTete = feuille.getRange(1, 1, 1, feuille.getLastColumn()).getValues()[0];
     const indices = {
       idResa: enTete.indexOf("ID Réservation"), idEvent: enTete.indexOf("Event ID"),

--- a/Maintenance.gs
+++ b/Maintenance.gs
@@ -21,7 +21,7 @@ const MOIS_RETENTION_LOGS = 12;      // Durée de conservation des logs d'activi
 function logAdminAction(action, statut) {
   try {
     const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
-    let feuilleLog = ss.getSheetByName("Admin_Logs");
+    let feuilleLog = ss.getSheetByName(SHEET_ADMIN_LOGS);
     if (!feuilleLog) {
       feuilleLog = ss.insertSheet("Admin_Logs");
       feuilleLog.appendRow(["Timestamp", "Utilisateur", "Action", "Statut"]);
@@ -44,7 +44,7 @@ function logAdminAction(action, statut) {
 function logActivity(idReservation, emailClient, resume, prix, statut) {
   try {
     const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
-    let feuilleLog = ss.getSheetByName("Logs");
+    let feuilleLog = ss.getSheetByName(SHEET_LOGS);
     if (!feuilleLog) {
       feuilleLog = ss.insertSheet("Logs");
       feuilleLog.appendRow(["Timestamp", "Reservation ID", "Client Email", "Résumé", "Montant", "Statut"]);
@@ -218,7 +218,7 @@ function sauvegarderDonnees() {
       }
     });
     
-    ssSauvegarde.deleteSheet(ssSauvegarde.getSheetByName('Sheet1'));
+    ssSauvegarde.deleteSheet(ssSauvegarde.getSheetByName(SHEET_DEFAULT));
     
     Logger.log(`Sauvegarde des données réussie. Fichier : ${ssSauvegarde.getUrl()}`);
     logAdminAction("Sauvegarde des données", `Succès : ${ssSauvegarde.getName()}`);
@@ -264,7 +264,7 @@ function purgerAnciennesDonnees() {
     const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
     
     // --- Purge de la feuille de facturation et des PDF ---
-    const feuilleFacturation = ss.getSheetByName("Facturation");
+    const feuilleFacturation = ss.getSheetByName(SHEET_FACTURATION);
     if (feuilleFacturation) {
         const enTeteFact = feuilleFacturation.getRange(1, 1, 1, feuilleFacturation.getLastColumn()).getValues()[0];
         const dateColFact = enTeteFact.indexOf("Date");
@@ -293,7 +293,7 @@ function purgerAnciennesDonnees() {
     }
 
     // --- Purge de la feuille de logs ---
-    const feuilleLog = ss.getSheetByName("Logs");
+    const feuilleLog = ss.getSheetByName(SHEET_LOGS);
     if (feuilleLog) {
         const enTeteLog = feuilleLog.getRange(1, 1, 1, feuilleLog.getLastColumn()).getValues()[0];
         const dateColLog = enTeteLog.indexOf("Timestamp");
@@ -346,7 +346,7 @@ function nettoyerOngletFacturation() {
   const ui = SpreadsheetApp.getUi();
   try {
     const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
-    const feuille = ss.getSheetByName('Facturation');
+    const feuille = ss.getSheetByName(SHEET_FACTURATION);
     if (!feuille) throw new Error("La feuille 'Facturation' est introuvable.");
 
     const header = feuille.getRange(1, 1, 1, feuille.getLastColumn()).getValues()[0].map(v => String(v || ''));
@@ -500,7 +500,7 @@ function reparerEntetesFacturation() {
   const ui = SpreadsheetApp.getUi();
   try {
     const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
-    const sh = ss.getSheetByName('Facturation');
+    const sh = ss.getSheetByName(SHEET_FACTURATION);
     if (!sh) throw new Error("Feuille 'Facturation' introuvable.");
     const lastCol = sh.getLastColumn();
     const headers = sh.getRange(1, 1, 1, lastCol).getValues()[0];
@@ -632,7 +632,7 @@ function resynchroniserEvenement(idReservation) {
   }
   try {
     const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
-    const feuille = ss.getSheetByName('Facturation');
+    const feuille = ss.getSheetByName(SHEET_FACTURATION);
     if (!feuille) throw new Error("La feuille 'Facturation' est introuvable.");
 
     const enTetes = [
@@ -687,7 +687,7 @@ function purgerEventIdInexistant(idReservation) {
   }
   try {
     const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
-    const feuille = ss.getSheetByName('Facturation');
+    const feuille = ss.getSheetByName(SHEET_FACTURATION);
     if (!feuille) throw new Error("La feuille 'Facturation' est introuvable.");
 
     const enTetes = ['ID Réservation', 'Event ID', 'Note Interne'];
@@ -738,7 +738,7 @@ function verifierCoherenceCalendrier() {
 
   try {
     const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
-    const feuille = ss.getSheetByName("Facturation");
+    const feuille = ss.getSheetByName(SHEET_FACTURATION);
     if (!feuille) throw new Error("La feuille 'Facturation' est introuvable.");
 
     const enTetesRequis = ["ID Réservation", "Event ID", "Date"];

--- a/Reservation.gs
+++ b/Reservation.gs
@@ -325,7 +325,7 @@ function trouverAlternativeProche(creneauCible, creneauxDisponibles) {
  * Récupère toutes les réservations pour un email client (et optionnellement une date).
  */
 function obtenirReservationsPourClient(email, date) {
-  var sheet = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName('Facturation');
+  var sheet = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName(SHEET_FACTURATION);
   var data = sheet.getDataRange().getValues();
   var headers = data[0];
   var emailIndex = headers.indexOf("Client (Email)");


### PR DESCRIPTION
## Summary
- add documented sheet name constants in Configuration
- replace sheet lookups with constants across codebase

## Testing
- `npm test` *(fails: Missing script "test")*
- `node -e "require('./Debug.gs');"` *(fails: ADMIN_EMAIL is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b7dbb3bffc83269e07653fa49adb7d