### PR TITLE
docs: clarify TARIFS schema

### DIFF
--- a/Configuration.gs
+++ b/Configuration.gs
@@ -70,25 +70,28 @@ const THEMES = {
 // =================================================================
 // SYSTÈME DE TARIFICATION FLEXIBLE - SOURCE UNIQUE DE VÉRITÉ
 // =================================================================
-// Pilotez tous les tarifs depuis cet objet.
-// 'base': Prix pour le premier arrêt (la prise en charge).
-// 'arrets': Un tableau des prix pour les arrêts suivants.
-//           Le dernier prix s'applique à tous les arrêts au-delà.
+// TARIFS schema:
+// {
+//   'Type': {        // ex: 'Normal', 'Samedi', 'Urgent', 'Special'
+//     base: number,  // Prix du premier arrêt (prise en charge)
+//     arrets: number[] // Tarifs des arrêts suivants; le dernier s'applique au-delà
+//   }
+// }
 // Grille tarifaire (Normal): 1=15€, 2=20€, 3=23€, 4=27€, 5=32€, 6 et + = 37€
 const TARIFS = {
-  'Normal': {
+  'Normal': { // Tarifs standard du lundi au vendredi
     base: 15,
     arrets: [5, 4, 3, 4, 5] // Prix pour Arrêt 2, 3, 4, 5, et 6+
   },
-  'Samedi': {
+  'Samedi': { // Livraisons effectuées le samedi
     base: 25,
     arrets: [5, 4, 3, 4, 5]
   },
-  'Urgent': {
+  'Urgent': { // Réservations dans le délai URGENT_THRESHOLD_MINUTES
     base: 20,
     arrets: [5, 4, 3, 4, 5]
   },
-  'Special': { // Vous pouvez ajouter autant de types que vous voulez
+  'Special': { // Cas particuliers ou tarifs temporaires
     base: 30,
     arrets: [5, 4, 3, 4, 5]
   }

--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ See `AGENTS.md` for project structure, coding style, testing steps, and the pull
 - `clasp open`: Open the Apps Script project in the browser.
 - `clasp push -f`: Push local code to Apps Script (force overwrite).
 
+## Tarifs
+Les tarifs sont centralisés dans `Configuration.gs` via l'objet `TARIFS`.
+
+- **Normal** – livraisons standard du lundi au vendredi.
+- **Samedi** – appliqué aux livraisons du samedi.
+- **Urgent** – déclenché si la réservation est dans le seuil `URGENT_THRESHOLD_MINUTES`.
+- **Special** – base pour tarifs ponctuels ou expérimentaux.
+
+Chaque entrée suit la forme `{ base: <prix premier arrêt>, arrets: [<arrêt 2>, ...] }`.
+Dupliquez une entrée existante pour ajouter un nouveau type puis ajustez les montants.
+
 ## Clasp Version
 Le projet utilise `@google/clasp` version `2.5.0` en local comme en CI.
 


### PR DESCRIPTION
## Summary
- document TARIFS object structure and inline type usage
- guide admins on extending tariff types via README

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7dbce016c83269b89220f19b2978c