### PR TITLE
Retire menu audit Drive et ajoute test stub

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -15,8 +15,7 @@ function onOpen() {
       .addItem('Envoyer les factures contrôlées', 'envoyerFacturesControlees')
       .addItem("Archiver les factures du mois dernier", "archiverFacturesDuMois")
       .addSeparator()
-      .addItem("Vérifier la cohérence du calendrier", "verifierCoherenceCalendrier")
-      .addItem("Lancer un audit des partages Drive", "lancerAuditDrive");
+      .addItem("Vérifier la cohérence du calendrier", "verifierCoherenceCalendrier");
 
   const sousMenuMaintenance = ui.createMenu('Maintenance')
       .addItem("Sauvegarder le code du projet", "sauvegarderCodeProjet")
@@ -25,7 +24,8 @@ function onOpen() {
       .addItem("Purger les anciennes données (RGPD)", "purgerAnciennesDonnees");
       
   const sousMenuDebug = ui.createMenu('Debug')
-      .addItem("Lancer tous les tests", "lancerTousLesTests");
+      .addItem("Lancer tous les tests", "lancerTousLesTests")
+      .addItem("Tester audit Drive", "testerAuditDrive");
 
   sousMenuMaintenance.addItem("Nettoyer l'onglet Facturation", "nettoyerOngletFacturation");
   sousMenuMaintenance.addItem("Reparer entetes Facturation", "reparerEntetesFacturation");

--- a/Debug.gs
+++ b/Debug.gs
@@ -35,6 +35,7 @@ function lancerTousLesTests() {
   testerGestionClient();
   testerAdministration();
   testerMaintenance();
+  testerAuditDrive();
 
   Logger.log("===== FIN DE LA SUITE DE TESTS COMPLÈTE =====");
   // SpreadsheetApp.getUi().alert("Tests terminés. Consultez les journaux (Logs) pour les résultats détaillés.");
@@ -176,9 +177,19 @@ function testerMaintenance() {
   Logger.log("\n--- Test de Maintenance.gs ---");
   logAdminAction("TEST", "Test de la fonction de log");
   Logger.log("SUCCESS: logAdminAction() exécuté. Vérifiez l'onglet Admin_Logs.");
-  
+
   notifyAdminWithThrottle("TEST_ERREUR", "Email de test", "Ceci est un test de la fonction de notification.");
   Logger.log("SUCCESS: notifyAdminWithThrottle() exécuté. Vérifiez votre boîte de réception.");
+}
+
+function testerAuditDrive() {
+  Logger.log("\n--- Test de lancerAuditDrive() ---");
+  try {
+    lancerAuditDrive();
+    Logger.log("SUCCESS: lancerAuditDrive() s'est exécutée sans erreur.");
+  } catch (e) {
+    Logger.log(`FAILURE: lancerAuditDrive() a échoué. Erreur: ${e.message}`);
+  }
 }
 
 /**

--- a/Maintenance.gs
+++ b/Maintenance.gs
@@ -828,3 +828,12 @@ function verifierCoherenceCalendrier() {
     ui.alert("Erreur Critique", `L'audit a échoué : ${e.message}`, ui.ButtonSet.OK);
   }
 }
+
+/**
+ * Audit basique des partages Drive (stub).
+ * Affiche un message indiquant que la fonctionnalité n'est pas encore disponible.
+ */
+function lancerAuditDrive() {
+  const ui = SpreadsheetApp.getUi();
+  ui.alert('Audit Drive', 'Fonctionnalité non implémentée.', ui.ButtonSet.OK);
+}


### PR DESCRIPTION
## Summary
- Supprime l'entrée de menu Drive audit non prête
- Ajoute un stub `lancerAuditDrive` et un test `testerAuditDrive`
- Expose le test via le menu Debug

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7dd1b1e8c83268824c01214165504