### PR TITLE
feat: add debug menu feature flag

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -23,9 +23,6 @@ function onOpen() {
       .addItem("Sauvegarder les données", "sauvegarderDonnees")
       .addItem("Vérifier structure des feuilles", "menuVerifierStructureFeuilles")
       .addItem("Purger les anciennes données (RGPD)", "purgerAnciennesDonnees");
-      
-  const sousMenuDebug = ui.createMenu('Debug')
-      .addItem("Lancer tous les tests", "lancerTousLesTests");
 
   sousMenuMaintenance.addItem("Nettoyer l'onglet Facturation", "nettoyerOngletFacturation");
   sousMenuMaintenance.addItem("Reparer entetes Facturation", "reparerEntetesFacturation");
@@ -35,8 +32,15 @@ function onOpen() {
   if (CALENDAR_PURGE_ENABLED) {
     sousMenuMaintenance.addItem("Purger Event ID introuvable", "menuPurgerEventId");
   }
-  menuPrincipal.addSubMenu(sousMenuMaintenance).addToUi();
-  menuPrincipal.addSubMenu(sousMenuDebug).addToUi();
+  menuPrincipal.addSubMenu(sousMenuMaintenance);
+
+  if (DEBUG_MENU_ENABLED) {
+    const sousMenuDebug = ui.createMenu('Debug')
+        .addItem("Lancer tous les tests", "lancerTousLesTests");
+    menuPrincipal.addSubMenu(sousMenuDebug);
+  }
+
+  menuPrincipal.addToUi();
 }
 
 /**
@@ -68,12 +72,15 @@ function doGet(e) {
                 templateGestion.ADMIN_EMAIL = ADMIN_EMAIL;
                 return templateGestion.evaluate().setTitle("Mon Espace Client").setXFrameOptionsMode(HtmlService.XFrameOptionsMode.DEFAULT);
             case 'debug':
-                 const debugEmail = Session.getActiveUser().getEmail();
-                if (debugEmail && debugEmail.toLowerCase() === ADMIN_EMAIL.toLowerCase()) {
-                    return HtmlService.createHtmlOutputFromFile('Debug_Interface').setTitle("Panneau de Débogage");
-                } else {
-                    return HtmlService.createHtmlOutput('<h1>Accès Refusé</h1><p>Vous n\'avez pas les permissions nécessaires.</p>');
+                if (DEBUG_MENU_ENABLED) {
+                    const debugEmail = Session.getActiveUser().getEmail();
+                    if (debugEmail && debugEmail.toLowerCase() === ADMIN_EMAIL.toLowerCase()) {
+                        return HtmlService.createHtmlOutputFromFile('Debug_Interface').setTitle("Panneau de Débogage");
+                    } else {
+                        return HtmlService.createHtmlOutput('<h1>Accès Refusé</h1><p>Vous n\\'avez pas les permissions nécessaires.</p>');
+                    }
                 }
+                return HtmlService.createHtmlOutput('<h1>Accès Refusé</h1><p>Debug désactivé.</p>');
             case 'infos':
                 if (PRIVACY_LINK_ENABLED) {
                     return HtmlService.createHtmlOutputFromFile('Infos_confidentialite')

--- a/Configuration.gs
+++ b/Configuration.gs
@@ -52,6 +52,8 @@ const CA_EN_COURS_ENABLED = true; // Active l'affichage du CA en cours
 
 const DEMO_RESERVATION_ENABLED = false; // Sert une page de réservation démo ultra-légère
 
+const DEBUG_MENU_ENABLED = false; // Affiche le sous-menu Debug et l'interface associée
+
 const SLOTS_AMPM_ENABLED = false; // Sépare les créneaux matin/après-midi
 const THEME_V2_ENABLED = false; // Active la nouvelle version du thème
 const BILLING_V2_DRYRUN = false; // Mode test pour la facturation V2 (aucune écriture)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ Le projet utilise `@google/clasp` version `2.5.0` en local comme en CI.
 2. `clasp push -f` puis créer une nouvelle version pour déploiement.
 3. Pour rollback, remettre le flag à `false` et redéployer la version précédente.
 
+## Menu Debug
+1. Activer `DEBUG_MENU_ENABLED` dans `Configuration.gs`.
+2. `clasp push -f` puis créer une nouvelle version pour déploiement.
+3. Pour rollback, remettre le flag à `false` et redéployer la version précédente.
+
 ## Tests Manuels
 - Déplacer une facture vers `Facturation_Aout_2025` puis vérifier qu'elle reste visible et envoyable depuis l'espace client.
 


### PR DESCRIPTION
## Summary
- add DEBUG_MENU_ENABLED flag
- show Debug menu and interface only when flag enabled
- document how to toggle debug menu

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7dd1c293c8326941883dc255eeafa