### PR TITLE
Conditionally load theme selector

### DIFF
--- a/Admin_Interface.html
+++ b/Admin_Interface.html
@@ -25,20 +25,22 @@
     </header>
 
     <div class="carte barre-outils">
-      <div class="selecteur-date">
-        <label for="date-livraison">Afficher les courses pour le :</label>
-        <input type="date" id="date-livraison" class="champ-formulaire">
-      </div>
-      <button id="btn-tout-voir" class="btn btn-secondaire">Toutes les courses</button>
-      <button id="btn-ajouter-reservation" class="btn btn-primaire">Ajouter une course</button>
-      <div class="theme-selector">
-        <button id="btn-theme" class="btn btn-secondaire hidden" aria-haspopup="true" aria-expanded="false">Thème</button>
-        <div id="menu-theme" class="hidden" role="menu">
-          <button class="option-theme btn btn-secondaire" data-theme="clarte" role="menuitem">Clarté</button>
-          <button class="option-theme btn btn-secondaire" data-theme="nocturne" role="menuitem">Nocturne</button>
+        <div class="selecteur-date">
+          <label for="date-livraison">Afficher les courses pour le :</label>
+          <input type="date" id="date-livraison" class="champ-formulaire">
         </div>
-      </div>
-      <div id="ca-en-cours" class="hidden" role="status" aria-live="polite"></div>
+        <button id="btn-tout-voir" class="btn btn-secondaire">Toutes les courses</button>
+        <button id="btn-ajouter-reservation" class="btn btn-primaire">Ajouter une course</button>
+        <? if (THEME_SELECTION_ENABLED) { ?>
+          <div class="theme-selector">
+            <button id="btn-theme" class="btn btn-secondaire hidden" aria-haspopup="true" aria-expanded="false">Thème</button>
+            <div id="menu-theme" class="hidden" role="menu">
+              <button class="option-theme btn btn-secondaire" data-theme="clarte" role="menuitem">Clarté</button>
+              <button class="option-theme btn btn-secondaire" data-theme="nocturne" role="menuitem">Nocturne</button>
+            </div>
+          </div>
+        <? } ?>
+        <div id="ca-en-cours" class="hidden" role="status" aria-live="polite"></div>
     </div>
 
     <main id="conteneur-app">
@@ -62,7 +64,9 @@
   </div>
 
   <div id="conteneur-notifications" role="alert" aria-live="assertive"></div>
-  <?!= include('Script_ThemeSelector'); ?>
+  <? if (THEME_SELECTION_ENABLED) { ?>
+    <?!= include('Script_ThemeSelector'); ?>
+  <? } ?>
   <?!= include('Admin_JS'); ?>
 </body>
 </html>

--- a/Client_Espace.html
+++ b/Client_Espace.html
@@ -25,15 +25,17 @@
     </header>
 
     <main id="conteneur-app" class="hidden">
-      <div class="carte barre-outils">
-        <div class="theme-selector">
-          <button id="btn-theme" class="btn btn-secondaire hidden" aria-haspopup="true" aria-expanded="false">Thème</button>
-          <div id="menu-theme" class="hidden" role="menu">
-            <button class="option-theme btn btn-secondaire" data-theme="clarte" role="menuitem">Clarté</button>
-            <button class="option-theme btn btn-secondaire" data-theme="nocturne" role="menuitem">Nocturne</button>
-          </div>
+        <div class="carte barre-outils">
+          <? if (THEME_SELECTION_ENABLED) { ?>
+            <div class="theme-selector">
+              <button id="btn-theme" class="btn btn-secondaire hidden" aria-haspopup="true" aria-expanded="false">Thème</button>
+              <div id="menu-theme" class="hidden" role="menu">
+                <button class="option-theme btn btn-secondaire" data-theme="clarte" role="menuitem">Clarté</button>
+                <button class="option-theme btn btn-secondaire" data-theme="nocturne" role="menuitem">Nocturne</button>
+              </div>
+            </div>
+          <? } ?>
         </div>
-      </div>
       <div id="ca-client" class="carte" tabindex="0"></div>
       <div id="liste-reservations" class="carte">
         <h3>Vos prochaines courses</h3>
@@ -79,7 +81,9 @@
   </div>
 
   <div id="conteneur-notifications"></div>
-  <?!= include('Script_ThemeSelector'); ?>
+  <? if (THEME_SELECTION_ENABLED) { ?>
+    <?!= include('Script_ThemeSelector'); ?>
+  <? } ?>
   <?!= include('Client_JS'); ?>
 </body>
 </html>

--- a/Configuration.gs
+++ b/Configuration.gs
@@ -60,7 +60,7 @@ const POST_ENDPOINT_ENABLED = false; // Active le traitement des requêtes POST
 
 const PRIVACY_LINK_ENABLED = false; // Affiche le lien Infos & confidentialité
 
-const THEME_SELECTION_ENABLED = true; // Active le choix de thème côté client
+const THEME_SELECTION_ENABLED = false; // Active le choix de thème côté client
 const THEME_DEFAULT = 'nocturne';
 const THEMES = {
   clarte: 'branding/Theme_Clarte_CSS',

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Le projet utilise `@google/clasp` version `2.5.0` en local comme en CI.
 3. En cas de conflit, exécuter `npx @google/clasp pull` avant de retenter.
 
 ## Sélecteur de thème
-1. Activer `THEME_SELECTION_ENABLED` dans `Configuration.gs`.
+1. Activer `THEME_SELECTION_ENABLED` dans `Configuration.gs` (désactivé par défaut).
 2. `clasp push -f` puis créer une nouvelle version pour déploiement.
 3. Pour rollback, remettre le flag à `false` et redéployer la version précédente.
 

--- a/Reservation_Interface.html
+++ b/Reservation_Interface.html
@@ -255,7 +255,9 @@
   </div>
 
   <div id="conteneur-notifications" role="alert" aria-live="assertive"></div>
-  <?!= include('Script_ThemeSelector'); ?>
+  <? if (THEME_SELECTION_ENABLED) { ?>
+    <?!= include('Script_ThemeSelector'); ?>
+  <? } ?>
   <?!= include('Reservation_JS_UI'); ?>
   <?!= include('Reservation_JS_UI_Elements'); ?>
   <?!= include('Reservation_JS_Calendrier'); ?>


### PR DESCRIPTION
## Summary
- Guard all theme selector markup and `Script_ThemeSelector` includes with `THEME_SELECTION_ENABLED` checks
- Default `THEME_SELECTION_ENABLED` to `false`
- Document flag default in README

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7dd2348408326b5d066dbb459de4d