### PR TITLE
fix: dedupe theme selector styles

### DIFF
--- a/Admin_CSS.html
+++ b/Admin_CSS.html
@@ -315,29 +315,4 @@ body {
   right: 20px;
   z-index: 1001;
 }
-
-.notification {
-  /* Styles similaires à la page de réservation */
-}
-
-.theme-selector {
-  position: relative;
-}
-
-#menu-theme {
-  position: absolute;
-  top: 100%;
-  right: 0;
-  background-color: var(--bg);
-  border: 1px solid var(--muted);
-  padding: 8px;
-  border-radius: var(--radius);
-  z-index: 1000;
-}
-
-#menu-theme button {
-  display: block;
-  width: 100%;
-  margin: 4px 0;
-}
 </style>

--- a/Client_CSS.html
+++ b/Client_CSS.html
@@ -120,26 +120,6 @@ body {
   .reservation-item { grid-template-columns: 1fr; }
   .reservation-actions { flex-direction: row; }
 }
-.theme-selector {
-  position: relative;
-}
-
-#menu-theme {
-  position: absolute;
-  top: 100%;
-  right: 0;
-  background-color: var(--gris-clair);
-  border: 1px solid var(--couleur-bordure);
-  padding: 8px;
-  border-radius: 8px;
-  z-index: 1000;
-}
-
-#menu-theme button {
-  display: block;
-  width: 100%;
-  margin: 4px 0;
-}
 </style>
 
 

--- a/branding/Theme_Clarte_CSS.html
+++ b/branding/Theme_Clarte_CSS.html
@@ -13,4 +13,25 @@ body {
   color: var(--gris-fonce);
   font-family: 'Montserrat', sans-serif;
 }
+
+.theme-selector {
+  position: relative;
+}
+
+#menu-theme {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  background-color: var(--gris-clair, var(--bg));
+  border: 1px solid var(--couleur-bordure, var(--muted));
+  padding: 8px;
+  border-radius: var(--radius, 8px);
+  z-index: 1000;
+}
+
+#menu-theme button {
+  display: block;
+  width: 100%;
+  margin: 4px 0;
+}
 </style>

--- a/branding/Theme_Nocturne_CSS.html
+++ b/branding/Theme_Nocturne_CSS.html
@@ -13,4 +13,25 @@ body {
   color: var(--gris-fonce);
   font-family: 'Montserrat', sans-serif;
 }
+
+.theme-selector {
+  position: relative;
+}
+
+#menu-theme {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  background-color: var(--gris-clair, var(--bg));
+  border: 1px solid var(--couleur-bordure, var(--muted));
+  padding: 8px;
+  border-radius: var(--radius, 8px);
+  z-index: 1000;
+}
+
+#menu-theme button {
+  display: block;
+  width: 100%;
+  margin: 4px 0;
+}
 </style>


### PR DESCRIPTION
## Summary
- remove unused admin notification rule
- centralize theme selector menu styles in theme CSS

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b7dd246c6083268f71a2bfc8bfea29