### PR TITLE
fix: centralise theme variables

### DIFF
--- a/Client_CSS.html
+++ b/Client_CSS.html
@@ -3,19 +3,7 @@
                       FEUILLE DE STYLE - ESPACE CLIENT
    ================================================================= */
 
-/* --- VARIABLES DE COULEURS ET STYLES DE BASE --- */
-:root {
-  --couleur-primaire: #8e44ad; /* Violet */
-  --couleur-secondaire: #3498db; /* Bleu */
-  --couleur-succes: #5dade2; /* Bleu clair */
-  --couleur-erreur: #c0392b; /* Rouge */
-  --gris-clair: #f9f9f9;
-  --gris-moyen: #6c757d;
-  --gris-fonce: #343a40;
-  --couleur-bordure: #e9ecef;
-  --police-principale: 'Montserrat', sans-serif;
-  --ombre-portee: 0 8px 25px rgba(0, 0, 0, 0.07);
-}
+<?!= include('Styles'); ?>
 
 body {
   font-family: var(--police-principale);

--- a/Styles.html
+++ b/Styles.html
@@ -11,6 +11,16 @@
   --shadow:0 6px 18px rgba(0,0,0,.18);
   --grad:linear-gradient(135deg,var(--violet),var(--bleu));
   --grad-soft:linear-gradient(135deg,color-mix(in oklab,var(--violet) 85%, #fff 15%),color-mix(in oklab,var(--bleu) 85%, #fff 15%));
+  --couleur-primaire: var(--violet);
+  --couleur-secondaire: var(--bleu);
+  --couleur-succes: var(--bleu-clair);
+  --couleur-erreur: #c0392b;
+  --gris-clair: #f9f9f9;
+  --gris-moyen: #6c757d;
+  --gris-fonce: #343a40;
+  --couleur-bordure: #e9ecef;
+  --police-principale: var(--font);
+  --ombre-portee: var(--shadow);
 }
 *{box-sizing:border-box}
 html,body{margin:0;padding:0;font-family:var(--font);background:var(--bg);color:var(--txt)}


### PR DESCRIPTION
## Summary
- move color and font variables into global Styles
- include Styles in client CSS so all pages share theme

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b7dd275cac8326a3405b20027e725d