### PR TITLE
fix: use Montserrat for logo text

### DIFF
--- a/Logo.html
+++ b/Logo.html
@@ -24,7 +24,7 @@ Description: Ce fichier contient le code SVG du logo de l'entreprise.
     </defs>
     <path d="M 60 40 C 40 40, 40 70, 60 70 M 60 55 L 30 55 M 60 70 C 80 70, 90 60, 85 45 Q 95 55 105 50" stroke="url(#airyGradient)" stroke-width="4" stroke-linecap="round" fill="none"/>
     <g text-anchor="start">
-        <text x="120" y="62" font-family="Lato, sans-serif" font-size="28" font-weight="700" fill="#212529">ELS</text>
+        <text x="120" y="62" font-family="Montserrat, sans-serif" font-size="28" font-weight="700" fill="#212529">ELS</text>
     </g>
   </svg>
 </div>


### PR DESCRIPTION
## Summary
- switch logo text to Montserrat font for consistency with brand guidelines

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7dd4d9e5483269f6dcf9bc9a99a48