### PR TITLE
fix: warn when clasp CLI missing

### DIFF
--- a/tools/clasp-helper.ps1
+++ b/tools/clasp-helper.ps1
@@ -4,6 +4,11 @@
 Add-Type -AssemblyName System.Windows.Forms
 Add-Type -AssemblyName System.Drawing
 
+if (-not (Get-Command clasp -ErrorAction SilentlyContinue)) {
+  [System.Windows.Forms.MessageBox]::Show("Le CLI 'clasp' est requis et doit être disponible dans le PATH.",'Clasp Tools',[System.Windows.Forms.MessageBoxButtons]::OK,[System.Windows.Forms.MessageBoxIcon]::Error) | Out-Null
+  return
+}
+
 function New-Form {
   $form = New-Object System.Windows.Forms.Form
   $form.Text = "Clasp Tools"


### PR DESCRIPTION
## Summary
- check for clasp CLI before building the form in clasp-helper
- show message box and exit if clasp is unavailable

## Testing
- `mv node_modules/.bin/clasp node_modules/.bin/clasp.bak`
- `pwsh tools/clasp-helper.ps1` *(fails: command not found: pwsh)*


------
https://chatgpt.com/codex/tasks/task_e_68b92b4f591c832695aaf7d38045e54e