### PR TITLE
fix: validate clasp before helper run

### DIFF
--- a/clasp-helper.cmd
+++ b/clasp-helper.cmd
@@ -3,6 +3,15 @@ setlocal
 set "SCRIPT_DIR=%~dp0"
 set "REPO_ROOT=%SCRIPT_DIR%."
 
+cd /d "%REPO_ROOT%"
+
+where clasp >nul 2>&1
+if errorlevel 1 (
+  echo [Erreur] L'outil clasp est introuvable. Veuillez l'installer ou l'ajouter au PATH.
+  pause
+  exit /b 1
+)
+
 where pwsh >nul 2>&1
 if %errorlevel%==0 (
   set "PS=pwsh"


### PR DESCRIPTION
## Summary
- ensure clasp-helper.cmd starts in repo root and fails fast when clasp is missing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `wine cmd /c dir` *(fails: /usr/bin/wine: 40: exec: /usr/lib/wine/wine: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68b92b54acc48326922647a3125f2f8a