### PR TITLE
Fix: Correct theme switcher display and finalize themes

### DIFF
--- a/Client_Espace.html
+++ b/Client_Espace.html
@@ -27,25 +27,15 @@
     <main id="conteneur-app" class="hidden">
 
       <div class="carte barre-outils">
-        <div class="theme-selector">
-          <button id="btn-theme" class="btn btn-secondaire btn--client hidden" aria-haspopup="true" aria-expanded="false">Thème</button>
+        <? if (THEME_SELECTION_ENABLED) { ?>
+          <div class="theme-selector">
+            <button id="btn-theme" class="btn btn-secondaire btn--client hidden" aria-haspopup="true" aria-expanded="false">Thème</button>
             <div id="menu-theme" class="hidden" role="menu">
               <button class="option-theme btn btn-secondaire btn--client" data-theme="clarte" role="menuitem">Clarté</button>
               <button class="option-theme btn btn-secondaire btn--client" data-theme="nocturne" role="menuitem">Nocturne</button>
             </div>
-
-        <div class="carte barre-outils">
-          <? if (THEME_SELECTION_ENABLED) { ?>
-            <div class="theme-selector">
-              <button id="btn-theme" class="btn btn-secondaire hidden" aria-haspopup="true" aria-expanded="false">Thème</button>
-              <div id="menu-theme" class="hidden" role="menu">
-                <button class="option-theme btn btn-secondaire" data-theme="clarte" role="menuitem">Clarté</button>
-                <button class="option-theme btn btn-secondaire" data-theme="nocturne" role="menuitem">Nocturne</button>
-              </div>
-            </div>
-          <? } ?>
-
-        </div>
+          </div>
+        <? } ?>
       <div id="ca-client" class="carte" tabindex="0"></div>
       <div id="liste-reservations" class="carte">
         <h3>Vos prochaines courses</h3>

--- a/branding/Theme_Clarte_CSS.html
+++ b/branding/Theme_Clarte_CSS.html
@@ -1,37 +1,76 @@
 <style>
-:root {
-  --couleur-primaire: #8e44ad;
-  --couleur-secondaire: #3498db;
-  --couleur-accent: #5dade2;
-  --gris-clair: #ffffff;
-  --gris-moyen: #5f6b7a;
-  --gris-fonce: #1e2430;
-  --couleur-bordure: #e6ebf1;
-}
-body {
-  background-color: var(--gris-clair);
-  color: var(--gris-fonce);
-  font-family: 'Montserrat', sans-serif;
-}
+  /* Thème Clarté (Light) */
+  :root {
+    --font: 'Montserrat', system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, 'Helvetica Neue', Arial, sans-serif;
+    --violet: #8e44ad;
+    --bleu: #3498db;
+    --bleu-clair: #5dade2;
+    --couleur-erreur: #c0392b;
 
-.theme-selector {
-  position: relative;
-}
+    /* Couleurs principales du thème clair */
+    --txt: #212529; /* Texte principal (presque noir) */
+    --bg: #f8f9fa;  /* Fond général (très clair) */
+    --bg-panel: #ffffff; /* Fond des cartes et modales (blanc) */
+    --muted: #6c757d;    /* Texte secondaire (gris) */
+    --couleur-bordure: #dee2e6; /* Bordures (gris clair) */
 
-#menu-theme {
-  position: absolute;
-  top: 100%;
-  right: 0;
-  background-color: var(--gris-clair, var(--bg));
-  border: 1px solid var(--couleur-bordure, var(--muted));
-  padding: 8px;
-  border-radius: var(--radius, 8px);
-  z-index: 1000;
-}
+    /* Variables de base */
+    --radius: 12px;
+    --radius-pill: 9999px;
+    --shadow: 0 6px 18px rgba(0, 0, 0, 0.08);
+    --grad: linear-gradient(135deg, var(--violet), var(--bleu));
+    --grad-soft: linear-gradient(135deg, color-mix(in oklab, var(--violet) 85%, #fff 15%), color-mix(in oklab, var(--bleu) 85%, #fff 15%));
 
-#menu-theme button {
-  display: block;
-  width: 100%;
-  margin: 4px 0;
-}
+    /* Alias sémantiques */
+    --couleur-primaire: var(--violet);
+    --couleur-secondaire: var(--bleu);
+    --couleur-succes: var(--bleu-clair);
+    --police-principale: var(--font);
+    --ombre-portee: var(--shadow);
+  }
+
+  /* Ajustements spécifiques pour le thème clair */
+  .btn-primaire {
+    color: #ffffff; /* Texte blanc sur fond violet/bleu */
+  }
+
+  .btn-secondaire {
+    background-color: #e9ecef;
+    color: #343a40;
+  }
+  .btn-secondaire:not(:disabled):hover {
+    background-color: #d1d6db;
+  }
+
+  .slot-btn {
+    color: var(--txt);
+    border-color: var(--couleur-bordure);
+  }
+
+  .slot-btn.standard:not(:disabled):hover {
+    background-color: color-mix(in oklab, var(--violet) 15%, transparent);
+    border-color: var(--violet);
+    color: var(--violet);
+  }
+  .slot-btn.standard.selected {
+    background-color: var(--violet);
+    border-color: var(--violet);
+    color: #ffffff;
+  }
+  .slot-btn.standard.selected .slot-rate-label {
+    color: #ffffff;
+  }
+
+  .indicateur-chargement-overlay {
+    background-color: rgba(255, 255, 255, 0.8);
+  }
+
+  .spinner {
+    border-color: #ced4da;
+    border-top-color: var(--violet);
+  }
+
+  .modale-contenu, .carte, .panel {
+    background-color: var(--bg-panel);
+  }
 </style>

--- a/branding/Theme_Nocturne_CSS.html
+++ b/branding/Theme_Nocturne_CSS.html
@@ -1,37 +1,75 @@
 <style>
-:root {
-  --couleur-primaire: #8e44ad;
-  --couleur-secondaire: #3498db;
-  --couleur-accent: #5dade2;
-  --gris-clair: #0f1422;
-  --gris-moyen: #a7b0bf;
-  --gris-fonce: #e9edf5;
-  --couleur-bordure: #2a3246;
-}
-body {
-  background-color: var(--gris-clair);
-  color: var(--gris-fonce);
-  font-family: 'Montserrat', sans-serif;
-}
+  /* Thème Nocturne (Dark) */
+  :root {
+    --font: 'Montserrat', system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, 'Helvetica Neue', Arial, sans-serif;
+    --violet: #8e44ad;
+    --bleu: #3498db;
+    --bleu-clair: #5dade2;
+    --couleur-erreur: #e74c3c;
 
-.theme-selector {
-  position: relative;
-}
+    /* Couleurs principales du thème sombre */
+    --txt: #e9edf5;      /* Texte principal (presque blanc) */
+    --bg: #0b0e13;      /* Fond général (très sombre) */
+    --bg-panel: #101724; /* Fond des cartes et modales (légèrement plus clair) */
+    --muted: #8492a6;    /* Texte secondaire (gris) */
+    --couleur-bordure: #2a3246; /* Bordures (bleu/gris sombre) */
 
-#menu-theme {
-  position: absolute;
-  top: 100%;
-  right: 0;
-  background-color: var(--gris-clair, var(--bg));
-  border: 1px solid var(--couleur-bordure, var(--muted));
-  padding: 8px;
-  border-radius: var(--radius, 8px);
-  z-index: 1000;
-}
+    /* Variables de base */
+    --radius: 12px;
+    --radius-pill: 9999px;
+    --shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
+    --grad: linear-gradient(135deg, var(--violet), var(--bleu));
+    --grad-soft: linear-gradient(135deg, color-mix(in oklab, var(--violet) 85%, #000 15%), color-mix(in oklab, var(--bleu) 85%, #000 15%));
 
-#menu-theme button {
-  display: block;
-  width: 100%;
-  margin: 4px 0;
-}
+    /* Alias sémantiques */
+    --couleur-primaire: var(--violet);
+    --couleur-secondaire: var(--bleu);
+    --couleur-succes: var(--bleu-clair);
+    --police-principale: var(--font);
+    --ombre-portee: var(--shadow);
+  }
+
+  /* Ajustements spécifiques pour le thème sombre */
+  .btn-primaire {
+    color: #ffffff;
+  }
+
+  .btn-secondaire {
+    background-color: #2a3246;
+    color: var(--txt);
+  }
+  .btn-secondaire:not(:disabled):hover {
+    background-color: #384259;
+  }
+
+  .slot-btn {
+    color: var(--txt);
+    border-color: var(--couleur-bordure);
+  }
+
+  .slot-btn.standard:not(:disabled):hover {
+    background-color: color-mix(in oklab, var(--violet) 25%, transparent);
+    border-color: var(--violet);
+  }
+  .slot-btn.standard.selected {
+    background-color: var(--violet);
+    border-color: var(--violet);
+    color: #ffffff;
+  }
+  .slot-btn.standard.selected .slot-rate-label {
+    color: #ffffff;
+  }
+
+  .indicateur-chargement-overlay {
+    background-color: rgba(11, 14, 19, 0.8);
+  }
+
+  .spinner {
+    border-color: #2a3246;
+    border-top-color: var(--violet);
+  }
+
+  .modale-contenu, .carte, .panel {
+    background-color: var(--bg-panel);
+  }
 </style>

--- a/jules-scratch/verification/verify_themes.py
+++ b/jules-scratch/verification/verify_themes.py
@@ -1,0 +1,45 @@
+import pytest
+from playwright.sync_api import Page, expect
+
+def test_theme_switcher(page: Page):
+    """
+    This test verifies that the theme switcher functionality is working.
+    It loads the page, takes a screenshot of the default (dark) theme,
+    switches to the light theme, and takes another screenshot to
+    confirm the change.
+    """
+
+    # 1. Arrange: Go to the application URL.
+    page.goto("https://script.google.com/macros/s/AKfycbzRzts0VCkAMdjmBYVdWXsAU6QzfThIgoy4Uu4vzb218sFriBlbEHdnGDAfIn7vYI-N/exec")
+
+    # Wait for the main calendar grid to be visible, indicating the app has loaded.
+    expect(page.locator("#grille-calendrier")).to_be_visible(timeout=20000)
+
+    # Give it an extra moment for any animations or late-loading elements.
+    page.wait_for_timeout(1000)
+
+    # 2. Act & Screenshot 1: Capture the default (dark) theme.
+    page.screenshot(path="jules-scratch/verification/dark_theme.png")
+
+    # 3. Act: Switch to the light theme.
+    theme_button = page.locator("#btn-theme")
+    # The button might be hidden if the feature flag isn't working, so we assert its visibility.
+    expect(theme_button).to_be_visible()
+    theme_button.click()
+
+    # Find and click the "Clarté" (light theme) button in the menu.
+    light_theme_option = page.get_by_role("button", name="Clarté")
+    expect(light_theme_option).to_be_visible()
+    light_theme_option.click()
+
+    # Wait for the theme change to apply.
+    page.wait_for_timeout(1000)
+
+    # 4. Screenshot 2 & Assert: Capture the light theme.
+    # We will use this screenshot as the final verification artifact.
+    page.screenshot(path="jules-scratch/verification/light_theme.png")
+
+    # As a final check, we can assert something simple, like the background color.
+    # Note: This is a bit brittle, but good for a verification script.
+    body = page.locator("body")
+    expect(body).to_have_css("background-color", "rgb(248, 249, 250)") # --bg: #f8f9fa


### PR DESCRIPTION
This commit resolves a bug that prevented the theme switcher button from appearing on the Client Area page. It also includes the completed CSS for the light and dark themes as originally planned.

Bug Fix:
- Corrected a malformed HTML structure and removed a duplicated element ID (`#btn-theme`) in `Client_Espace.html`. This was the root cause of the button not being displayed correctly.
- Verified that `Admin_Interface.html` did not have the same issue.

Feature:
- Populated `Theme_Clarte_CSS.html` and `Theme_Nocturne_CSS.html` with a complete set of CSS variables to provide full light and dark theme support across the application.

# [Scope]: Short summary

> Contributor guide: see [AGENTS.md](../AGENTS.md) for structure, style, tests, and deploy steps.

## Description
- Purpose and context of this change.
- Link to issue/incident (if any).

## Changes
- High-level list of changes (modules, files, behavior).

## Screenshots (UI)
- Before/after or key states, if applicable.

## Testing
- [ ] Ran `lancerTousLesTests()` and reviewed `Logger` output (`Debug.gs`).
- [ ] Verified critical flows: reservation, calendar, client, admin.
- [ ] Smoke tested the web app locally via `clasp open` where relevant.

## Deployment
- [ ] Ran `clasp push -f`.
- [ ] Created a version `clasp version "vYYYYMMDD-HHmm"` (if needed).
- [ ] Deployed or reassigned deployment `clasp deploy -d "desc"` (if needed).

## Notes
- Additional risks, roll-back plan, or follow-ups.
