### PR TITLE
fix: replace innerHTML with DOM APIs [no-structure-change]

### DIFF
--- a/Reservation_Interface.html
+++ b/Reservation_Interface.html
@@ -96,47 +96,81 @@
     </section>
 
     <script>
-      (function(){
-        try {
-          const t = (typeof configServeur !== 'undefined' && configServeur.TARIFS) ? configServeur.TARIFS : {};
-          const normal = t['Normal'] || { base: '', arrets: [] };
-          const samedi = t['Samedi'] || { base: '' };
-          const urgent = t['Urgent'] || { base: '' };
-          const km = (typeof configServeur.KM_BASE !== 'undefined') ? configServeur.KM_BASE : '';
-          const min = (typeof configServeur.DUREE_BASE !== 'undefined') ? configServeur.DUREE_BASE : '';
-          const arrets = Array.isArray(normal.arrets) ? normal.arrets : [];
-          const items = arrets.map((v,i) => {
-            const label = (i === arrets.length - 1) ? `${i+2}e et +` : `${i+2}e`;
-            return `<li>${label} arrêt : ${v} &euro; TTC</li>`;
-          }).join('');
-          const html = `
-            <div class="tarif-carte">
-              <h3>Course de base</h3>
-              <ul>
-                <li>${normal.base} &euro; TTC</li>
-                <li>${km} km inclus</li>
-                <li>${min} min inclus</li>
-              </ul>
-              <a href="#vue-calendrier" class="btn btn-primaire">Réserver</a>
-            </div>
-            <div class="tarif-carte">
-              <h3>Arrêts supplémentaires</h3>
-              <ul>${items || '<li>—</li>'}</ul>
-            </div>
-            <div class="tarif-carte">
-              <h3>Options</h3>
-              <ul>
-                <li>Samedi (base): ${samedi.base} &euro; TTC</li>
-                <li>Urgent (base): ${urgent.base} &euro; TTC</li>
-              </ul>
-              <p style="font-size: 0.9em; color: #555; margin-top: 0.5rem;">
-                Le samedi est prioritaire sur l&#8217;urgent&nbsp;: une course le samedi applique toujours le tarif samedi, m&ecirc;me si elle est urgente.
-              </p>
-            </div>`;
-          const cont = document.querySelector('.tarifs-cartes');
-          if (cont) cont.innerHTML = html;
-        } catch(e) {}
-      })();
+        (function(){
+          try {
+            const t = (typeof configServeur !== 'undefined' && configServeur.TARIFS) ? configServeur.TARIFS : {};
+            const normal = t['Normal'] || { base: '', arrets: [] };
+            const samedi = t['Samedi'] || { base: '' };
+            const urgent = t['Urgent'] || { base: '' };
+            const km = (typeof configServeur.KM_BASE !== 'undefined') ? configServeur.KM_BASE : '';
+            const min = (typeof configServeur.DUREE_BASE !== 'undefined') ? configServeur.DUREE_BASE : '';
+            const arrets = Array.isArray(normal.arrets) ? normal.arrets : [];
+            const cont = document.querySelector('.tarifs-cartes');
+            if (!cont) return;
+            cont.textContent = '';
+
+            const carteBase = document.createElement('div');
+            carteBase.className = 'tarif-carte';
+            const h3Base = document.createElement('h3');
+            h3Base.textContent = 'Course de base';
+            const ulBase = document.createElement('ul');
+            [ `${normal.base} € TTC`, `${km} km inclus`, `${min} min inclus` ].forEach(txt => {
+              const li = document.createElement('li');
+              li.textContent = txt;
+              ulBase.appendChild(li);
+            });
+            const lienReserver = document.createElement('a');
+            lienReserver.href = '#vue-calendrier';
+            lienReserver.className = 'btn btn-primaire';
+            lienReserver.textContent = 'Réserver';
+            carteBase.appendChild(h3Base);
+            carteBase.appendChild(ulBase);
+            carteBase.appendChild(lienReserver);
+            cont.appendChild(carteBase);
+
+            const carteArrets = document.createElement('div');
+            carteArrets.className = 'tarif-carte';
+            const h3Arrets = document.createElement('h3');
+            h3Arrets.textContent = 'Arrêts supplémentaires';
+            const ulArrets = document.createElement('ul');
+            if (arrets.length > 0) {
+              arrets.forEach((v, i) => {
+                const label = (i === arrets.length - 1) ? `${i + 2}e et +` : `${i + 2}e`;
+                const li = document.createElement('li');
+                li.textContent = `${label} arrêt : ${v} € TTC`;
+                ulArrets.appendChild(li);
+              });
+            } else {
+              const li = document.createElement('li');
+              li.textContent = '—';
+              ulArrets.appendChild(li);
+            }
+            carteArrets.appendChild(h3Arrets);
+            carteArrets.appendChild(ulArrets);
+            cont.appendChild(carteArrets);
+
+            const carteOptions = document.createElement('div');
+            carteOptions.className = 'tarif-carte';
+            const h3Options = document.createElement('h3');
+            h3Options.textContent = 'Options';
+            const ulOptions = document.createElement('ul');
+            const liSamedi = document.createElement('li');
+            liSamedi.textContent = `Samedi (base): ${samedi.base} € TTC`;
+            const liUrgent = document.createElement('li');
+            liUrgent.textContent = `Urgent (base): ${urgent.base} € TTC`;
+            ulOptions.appendChild(liSamedi);
+            ulOptions.appendChild(liUrgent);
+            const pNote = document.createElement('p');
+            pNote.style.fontSize = '0.9em';
+            pNote.style.color = '#555';
+            pNote.style.marginTop = '0.5rem';
+            pNote.textContent = 'Le samedi est prioritaire sur l’urgent : une course le samedi applique toujours le tarif samedi, même si elle est urgente.';
+            carteOptions.appendChild(h3Options);
+            carteOptions.appendChild(ulOptions);
+            carteOptions.appendChild(pNote);
+            cont.appendChild(carteOptions);
+          } catch (e) {}
+        })();
     </script>
 
     <main id="app-conteneur" role="main" aria-label="Contenu principal de la page de réservation">

--- a/Reservation_JS_Panier.html
+++ b/Reservation_JS_Panier.html
@@ -50,30 +50,59 @@ function afficherPanier() {
   const { panier } = window.etat;
 
   if (panier.length === 0) {
-    ui.listePanier.innerHTML = '<p class="panier-vide">Votre panier est vide.</p>';
+    ui.listePanier.textContent = '';
+    const p = document.createElement('p');
+    p.className = 'panier-vide';
+    p.textContent = 'Votre panier est vide.';
+    ui.listePanier.appendChild(p);
     ui.panierPiedDePage.classList.add('hidden');
     return;
   }
 
-  ui.listePanier.innerHTML = panier.map(item => {
+  ui.listePanier.textContent = '';
+  panier.forEach(item => {
     const date = new Date(item.date + 'T00:00:00');
     const dateFormatee = date.toLocaleDateString('fr-FR', { day: 'numeric', month: 'long' });
-    const recurrenceInfo = item.isRecurrent ? '<small style="color: var(--couleur-recurrence, #ccc); display: block;">(Récurrence mensuelle)</small>' : '';
-    
-    return `
-      <li class="item-panier" data-id-item="${item.id}">
-        <div class="item-panier-infos">
-          <strong>Le ${dateFormatee} à ${item.startTime}</strong>
-          ${recurrenceInfo}
-          <small>${item.details}</small>
-        </div>
-        <div class="item-panier-actions">
-            <span class="item-panier-prix">${item.prix.toFixed(2)} €</span>
-            <button class="item-panier-supprimer" aria-label="Supprimer cet article">&times;</button>
-        </div>
-      </li>
-    `;
-  }).join('');
+
+    const li = document.createElement('li');
+    li.className = 'item-panier';
+    li.dataset.idItem = item.id;
+
+    const infosDiv = document.createElement('div');
+    infosDiv.className = 'item-panier-infos';
+
+    const strong = document.createElement('strong');
+    strong.textContent = `Le ${dateFormatee} à ${item.startTime}`;
+    infosDiv.appendChild(strong);
+
+    if (item.isRecurrent) {
+      const smallRec = document.createElement('small');
+      smallRec.style.color = 'var(--couleur-recurrence, #ccc)';
+      smallRec.style.display = 'block';
+      smallRec.textContent = '(Récurrence mensuelle)';
+      infosDiv.appendChild(smallRec);
+    }
+
+    const smallDetails = document.createElement('small');
+    smallDetails.textContent = item.details;
+    infosDiv.appendChild(smallDetails);
+
+    const actionsDiv = document.createElement('div');
+    actionsDiv.className = 'item-panier-actions';
+    const spanPrix = document.createElement('span');
+    spanPrix.className = 'item-panier-prix';
+    spanPrix.textContent = `${item.prix.toFixed(2)} €`;
+    const btnSupprimer = document.createElement('button');
+    btnSupprimer.className = 'item-panier-supprimer';
+    btnSupprimer.setAttribute('aria-label', 'Supprimer cet article');
+    btnSupprimer.textContent = '×';
+    actionsDiv.appendChild(spanPrix);
+    actionsDiv.appendChild(btnSupprimer);
+
+    li.appendChild(infosDiv);
+    li.appendChild(actionsDiv);
+    ui.listePanier.appendChild(li);
+  });
 
   const total = panier.reduce((acc, item) => acc + item.prix, 0);
   ui.panierTotalValeur.textContent = `~ ${total.toFixed(2)} €`; // Ajout de '~' car le total peut augmenter avec la récurrence

--- a/Reservation_JS_Tournee.html
+++ b/Reservation_JS_Tournee.html
@@ -66,10 +66,34 @@ function mettreAJourResumeTournee() {
   window.etat.tourneeEnCours.totalStops = totalStops;
   window.etat.tourneeEnCours.returnToPharmacy = returnToPharmacy;
   const estimation = calculerInfosTourneeClient(totalStops, returnToPharmacy, window.etat.tourneeEnCours.date, '12h00');
-  ui.resumeConfigTournee.innerHTML = `
-    <div><span>Durée estimée</span><strong>${estimation.duree} min</strong></div>
-    <div><span>Prix estimé</span><strong>~ ${estimation.prix.toFixed(2)} €</strong></div>
-    <div><span>Distance</span><strong>~ ${estimation.km} km</strong></div>`;
+  ui.resumeConfigTournee.textContent = '';
+  const divDuree = document.createElement('div');
+  const spanDuree = document.createElement('span');
+  spanDuree.textContent = 'Durée estimée';
+  const strongDuree = document.createElement('strong');
+  strongDuree.textContent = `${estimation.duree} min`;
+  divDuree.appendChild(spanDuree);
+  divDuree.appendChild(strongDuree);
+
+  const divPrix = document.createElement('div');
+  const spanPrix = document.createElement('span');
+  spanPrix.textContent = 'Prix estimé';
+  const strongPrix = document.createElement('strong');
+  strongPrix.textContent = `~ ${estimation.prix.toFixed(2)} €`;
+  divPrix.appendChild(spanPrix);
+  divPrix.appendChild(strongPrix);
+
+  const divKm = document.createElement('div');
+  const spanKm = document.createElement('span');
+  spanKm.textContent = 'Distance';
+  const strongKm = document.createElement('strong');
+  strongKm.textContent = `~ ${estimation.km} km`;
+  divKm.appendChild(spanKm);
+  divKm.appendChild(strongKm);
+
+  ui.resumeConfigTournee.appendChild(divDuree);
+  ui.resumeConfigTournee.appendChild(divPrix);
+  ui.resumeConfigTournee.appendChild(divKm);
 }
 
 /**
@@ -102,13 +126,33 @@ function afficherSelectionCreneaux(creneaux) {
   ui.modaleConfigTournee.classList.add('hidden');
   ui.titreModaleSelection.textContent = `Créneaux pour le ${new Date(tourneeEnCours.date + 'T00:00:00').toLocaleDateString('fr-FR', { day: 'numeric', month: 'long' })}`;
   if (!creneaux || creneaux.length === 0) {
-    ui.grilleSelectionCreneau.innerHTML = '<p class="panier-vide">Aucun créneau disponible pour cette configuration.</p>';
+    ui.grilleSelectionCreneau.textContent = '';
+    const p = document.createElement('p');
+    p.className = 'panier-vide';
+    p.textContent = 'Aucun créneau disponible pour cette configuration.';
+    ui.grilleSelectionCreneau.appendChild(p);
   } else {
-    ui.grilleSelectionCreneau.innerHTML = creneaux.map(creneau => {
+    ui.grilleSelectionCreneau.textContent = '';
+    creneaux.forEach(creneau => {
       const estimation = calculerInfosTourneeClient(tourneeEnCours.totalStops, tourneeEnCours.returnToPharmacy, tourneeEnCours.date, creneau);
       const estUrgent = estimation.typeCourse === 'Urgent';
-      return `<button class="slot-btn ${estUrgent ? 'urgent' : 'standard'}" data-creneau="${creneau}" data-prix="${estimation.prix}" data-tarif="${estimation.typeCourse}"><span class="slot-time">${creneau}</span><span class="slot-rate-label">${estimation.typeCourse}</span></button>`;
-    }).join('');
+      const btn = document.createElement('button');
+      btn.className = `slot-btn ${estUrgent ? 'urgent' : 'standard'}`;
+      btn.dataset.creneau = creneau;
+      btn.dataset.prix = estimation.prix;
+      btn.dataset.tarif = estimation.typeCourse;
+
+      const spanTime = document.createElement('span');
+      spanTime.className = 'slot-time';
+      spanTime.textContent = creneau;
+      const spanRate = document.createElement('span');
+      spanRate.className = 'slot-rate-label';
+      spanRate.textContent = estimation.typeCourse;
+      btn.appendChild(spanTime);
+      btn.appendChild(spanRate);
+
+      ui.grilleSelectionCreneau.appendChild(btn);
+    });
   }
   reinitialiserRecapCreneau();
   if(ui.btnAjouterAuPanier) ui.btnAjouterAuPanier.disabled = true;
@@ -197,16 +241,36 @@ function afficherModaleConfirmationRecurrence(resultats) {
   const modale = document.getElementById('modale-confirmation-recurrence');
   const listeUI = document.getElementById('liste-recurrence-details');
   modale.dataset.recurrenceData = JSON.stringify(resultats);
-  listeUI.innerHTML = resultats.map(res => {
-    let content = '';
+  listeUI.textContent = '';
+  resultats.forEach(res => {
+    const li = document.createElement('li');
+    if (res.status !== 'OK') li.classList.add('conflit');
+
+    const strongDate = document.createElement('strong');
+    strongDate.textContent = res.dateFormatee;
+    li.appendChild(strongDate);
+
     if (res.status === 'OK') {
-      content = `<strong>${res.dateFormatee}</strong> à ${res.creneau} <span class="status-ok">✔ Disponible</span>`;
+      li.appendChild(document.createTextNode(` à ${res.creneau} `));
+      const spanOk = document.createElement('span');
+      spanOk.className = 'status-ok';
+      spanOk.textContent = '✔ Disponible';
+      li.appendChild(spanOk);
     } else {
-      content = `<strong>${res.dateFormatee}</strong> - <span class="status-conflict">⚠ Conflit</span><br>
-                 Créneau initial ${res.original} indisponible. Alternative proposée : <strong>${res.creneau || 'Aucune'}</strong>`;
+      li.appendChild(document.createTextNode(' - '));
+      const spanConflict = document.createElement('span');
+      spanConflict.className = 'status-conflict';
+      spanConflict.textContent = '⚠ Conflit';
+      li.appendChild(spanConflict);
+      li.appendChild(document.createElement('br'));
+      li.appendChild(document.createTextNode(`Créneau initial ${res.original} indisponible. Alternative proposée : `));
+      const strongAlt = document.createElement('strong');
+      strongAlt.textContent = res.creneau || 'Aucune';
+      li.appendChild(strongAlt);
     }
-    return `<li class="${res.status === 'OK' ? '' : 'conflit'}">${content}</li>`;
-  }).join('');
+
+    listeUI.appendChild(li);
+  });
   modale.classList.remove('hidden');
 }
 


### PR DESCRIPTION
## Summary
- ensure reservation JS partials contain only script blocks
- switch panier, tournée and tariff rendering to DOM APIs instead of innerHTML
- avoid parser errors from injected HTML

## Testing
- `node --check /tmp/panier.js`
- `node --check /tmp/tournee.js`
- `node --check /tmp/interface_script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b993f732a48326a589f4a2754c5067