### PR TITLE
fix: conditionally load reservation UI v2

### DIFF
--- a/Reservation_Interface.html
+++ b/Reservation_Interface.html
@@ -307,8 +307,10 @@
   <? if (THEME_SELECTION_ENABLED) { ?>
     <?!= include('Script_ThemeSelector'); ?>
   <? } ?>
-  <?!= include('Reservation_JS_UI'); ?>
-  <?!= include('Reservation_JS_UI_Elements'); ?>
+  <? if (THEME_V2_ENABLED) { ?>
+    <?!= include('Reservation_JS_UI'); ?>
+    <?!= include('Reservation_JS_UI_Elements'); ?>
+  <? } ?>
   <?!= include('Reservation_JS_Calendrier'); ?>
   <?!= include('Reservation_JS_Panier'); ?>
   <?!= include('Reservation_JS_Client'); ?>

--- a/Reservation_JS_UI.html
+++ b/Reservation_JS_UI.html
@@ -1,15 +1,4 @@
-<!doctype html>
-<html lang="fr">
-<head>
-  <meta charset="utf-8">
-  <base target="_top">
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>ELS — Réservation</title>
-  <!-- Montserrat -->
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
-
-  <style>
+<style>
     :root{
       --violet:#8e44ad;
       --blue:#3498db;
@@ -92,9 +81,6 @@
     .link{color:var(--blue);text-decoration:none;font-weight:600}
     .link:focus-visible{outline:var(--focus)}
   </style>
-</head>
-
-<body>
   <header>
     <h1 aria-live="polite">Réservation livraison — ELS</h1>
   </header>
@@ -289,6 +275,4 @@
 
     document.addEventListener('DOMContentLoaded', boot);
   </script>
-</body>
-</html>
 


### PR DESCRIPTION
## Summary
- refactor Reservation_JS_UI.html into partial without document root tags
- load Reservation_JS_UI partial only when THEME_V2_ENABLED is true to avoid duplicate HTML structure

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9c4871958832692d66d7c894fe984