### PR TITLE
feat: add semainier feature flag

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -129,8 +129,10 @@ function doGet(e) {
         .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.DEFAULT);
     }
 
-    if (typeof RESERVATION_UI_V2_ENABLED !== 'undefined' && RESERVATION_UI_V2_ENABLED) {
-      return HtmlService.createHtmlOutputFromFile('Reservation_JS_UI')
+    if (typeof RESERVATION_UI_V2_ENABLED !== 'undefined' && RESERVATION_UI_V2_ENABLED && SEMAINIER_ENABLED) {
+      const tpl = HtmlService.createTemplateFromFile('Reservation_JS_UI');
+      tpl.SEMAINIER_ENABLED = SEMAINIER_ENABLED;
+      return tpl.evaluate()
         .setTitle(NOM_ENTREPRISE + " | Réservation")
         .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.DEFAULT);
     }
@@ -139,6 +141,7 @@ function doGet(e) {
     const conf = getConfigCached(); // Assurez-vous que getConfigCached existe et fonctionne
 
     // Assignation des variables au template
+    template.SEMAINIER_ENABLED = SEMAINIER_ENABLED;
     template.THEME_SELECTION_ENABLED = THEME_SELECTION_ENABLED;
     template.appUrl = ScriptApp.getService().getUrl();
     template.nomService = NOM_ENTREPRISE;
@@ -263,6 +266,9 @@ const PB = {
  * @return {Object} Modèle pour le semainier.
  */
 function listWeekSlots(weekStartIso) {
+  if (typeof SEMAINIER_ENABLED === 'undefined' || !SEMAINIER_ENABLED) {
+    throw new Error('Semainier désactivé.');
+  }
   const ws = weekStartIso || mondayIso_(new Date());
   const days = Array.from({ length: 7 }, (_, i) => addDays_(ws, i));
   const sh = ensureSheet_();
@@ -293,6 +299,9 @@ function listWeekSlots(weekStartIso) {
  * @return {Array<Object>} Horaires avec disponibilité.
  */
 function listAvailableTimes(dateIso, part) {
+  if (typeof SEMAINIER_ENABLED === 'undefined' || !SEMAINIER_ENABLED) {
+    throw new Error('Semainier désactivé.');
+  }
   const win = PB.WINDOWS[part];
   if (!win) return [];
   const all = buildTimes_(win[0], win[1], PB.STEP_MIN);
@@ -308,6 +317,9 @@ function listAvailableTimes(dateIso, part) {
  * @return {Object} Résultat avec identifiant.
  */
 function createReservation(payload) {
+  if (typeof SEMAINIER_ENABLED === 'undefined' || !SEMAINIER_ENABLED) {
+    throw new Error('Semainier désactivé.');
+  }
   const dateIso = payload?.date;
   const part = payload?.part;
   const start = payload?.start;

--- a/Configuration.gs
+++ b/Configuration.gs
@@ -112,6 +112,8 @@ const CLIENT_PORTAL_ENABLED = true;
 const PRIVACY_LINK_ENABLED = false;
 /** @const {boolean} Sépare l'affichage des créneaux en matin et après-midi. */
 const SLOTS_AMPM_ENABLED = false;
+/** @const {boolean} Active le semainier expérimental. */
+const SEMAINIER_ENABLED = false;
 /** @const {boolean} Agrège toutes les feuilles "Facturation*" lors du calcul des factures. */
 const BILLING_MULTI_SHEET_ENABLED = true;
 /** @const {boolean} Affiche le chiffre d'affaires en cours dans l'interface admin. */
@@ -217,6 +219,7 @@ function getConfig() {
     MOIS_RETENTION_LOGS: MOIS_RETENTION_LOGS,
     SEMAINIER_WINDOWS: SEMAINIER_WINDOWS,
     SEMAINIER_STEP_MIN: SEMAINIER_STEP_MIN,
+    SEMAINIER_ENABLED: SEMAINIER_ENABLED,
     SHEET_RESERVATIONS: SHEET_RESERVATIONS
   };
 }

--- a/Reservation_JS_UI.html
+++ b/Reservation_JS_UI.html
@@ -1,4 +1,5 @@
 <script>
+  const SEMAINIER_ENABLED = <?= SEMAINIER_ENABLED ?>;
   /**
    * LEGACY SHIM — TODO: remove once all deployments use the new UI.
    * Provides inert stubs for legacy global initializers and overwrites
@@ -252,8 +253,9 @@
 
   // -------- Chargement semaine (agrégats) --------
   function loadWeek(weekStartIso){
+    if (!SEMAINIER_ENABLED) return;
     const ws = weekStartIso || mondayIsoOf(document.getElementById('dateControl').value);
-    if (google?.script?.run){
+    if (SEMAINIER_ENABLED && google?.script?.run){
       google.script.run
         .withSuccessHandler(res => renderPillbox(res))
         .withFailureHandler(e => { console.error(e); toast('Erreur de chargement semaine.'); })
@@ -278,7 +280,7 @@
       this.el.hidden=false; this.sel=null; this.btnOk.disabled=true;
       this.title.textContent = `Choisir l’horaire — ${labelDay(dateIso)} • ${PART_LABEL[part]}`;
       this.list.innerHTML='…';
-      if (google?.script?.run){
+      if (SEMAINIER_ENABLED && google?.script?.run){
         google.script.run
           .withSuccessHandler(times => this.renderTimes(dateIso, part, times))
           .withFailureHandler(e => { console.error(e); toast('Erreur de lecture des horaires.'); })
@@ -299,14 +301,17 @@
         });
         this.list.appendChild(b);
       });
-      this.btnOk.onclick = ()=>{
-        if (!this.sel) return;
-        google?.script?.run
-          ?.withSuccessHandler(res=>{ toast('Réservation créée'+(res?.id?` #${res.id}`:'')); this.close(); loadWeek(mondayIsoOf(dateIso)); })
-          ?.withFailureHandler(e=>{ console.error(e); toast('Création impossible.'); })
-          ?.createReservation({ date: dateIso, part, start: this.sel });
-        if (!google?.script?.run){ this.close(); toast(`Mock: ${dateIso} ${part} ${this.sel}`); }
-      };
+        this.btnOk.onclick = ()=>{
+          if (!this.sel) return;
+          if (SEMAINIER_ENABLED && google?.script?.run) {
+            google.script.run
+              .withSuccessHandler(res=>{ toast('Réservation créée'+(res?.id?` #${res.id}`:'')); this.close(); loadWeek(mondayIsoOf(dateIso)); })
+              .withFailureHandler(e=>{ console.error(e); toast('Création impossible.'); })
+              .createReservation({ date: dateIso, part, start: this.sel });
+          } else if (!google?.script?.run) {
+            this.close(); toast(`Mock: ${dateIso} ${part} ${this.sel}`);
+          }
+        };
     },
     close(){ this.el.hidden=true; this.sel=null; this.btnOk.disabled=true; }
   };
@@ -323,7 +328,7 @@
     const today = document.getElementById('dateControl');
     const iso = today?.value || new Date().toISOString().slice(0,10);
     if (today) today.value = iso;
-    loadWeek(mondayIsoOf(iso));
+    if (SEMAINIER_ENABLED) loadWeek(mondayIsoOf(iso));
   });
   </script>
 

--- a/Utilitaires.gs
+++ b/Utilitaires.gs
@@ -157,6 +157,7 @@ function setUserTheme(theme) {
 function getConfiguration() {
   return {
     slotsAmpmEnabled: SLOTS_AMPM_ENABLED,
+    semainierEnabled: SEMAINIER_ENABLED,
     themeV2Enabled: THEME_V2_ENABLED,
     billingV2Dryrun: BILLING_V2_DRYRUN,
     privacyLinkEnabled: PRIVACY_LINK_ENABLED


### PR DESCRIPTION
## Summary
- add SEMAINIER_ENABLED flag in configuration and expose through config APIs
- gate semainier APIs and UI behind the new flag, falling back to legacy calendar
- surface new flag to client configuration helpers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9d5f9308483269fee7418042f1f4b