### PR TITLE
fix: remove unused calendar styles

### DIFF
--- a/Reservation_JS_UI.html
+++ b/Reservation_JS_UI.html
@@ -75,22 +75,6 @@
       background:#fff;border-radius:var(--radius);
       box-shadow:0 6px 20px rgba(17,24,39,.06);padding:14px
     }
-    .calendar{
-      display:grid;grid-template-columns:repeat(7,1fr);gap:8px
-    }
-    .cal-head{display:grid;grid-template-columns:repeat(7,1fr);gap:8px;margin-bottom:8px;color:var(--muted);font-weight:600}
-    .cal-cell{
-      min-height:82px;border-radius:14px;background:var(--bg-alt);padding:8px;position:relative;
-      display:flex;flex-direction:column;gap:6px
-    }
-    .cal-cell[data-fill]{
-      background:linear-gradient(135deg,var(--violet),var(--blue));
-      color:#fff;
-    }
-    .badge{
-      display:inline-block;border-radius:999px;padding:4px 10px;font-size:12px;font-weight:600;
-      background:#fff;color:var(--violet)
-    }
     .row{display:flex;gap:10px;flex-wrap:wrap}
     .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
     .toast{


### PR DESCRIPTION
## Summary
- remove legacy calendar style rules

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b9d6033e208326abaafd7be9076c9b