### PR TITLE
fix: restore semainier constant with safe defaults

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -254,9 +254,9 @@ function doPost(e) {
  */
 // ====== PARAMÈTRES SEMAINIER ======
 const PB = {
-  SHEET_NAME: SHEET_RESERVATIONS,
-  STEP_MIN: SEMAINIER_STEP_MIN,
-  WINDOWS: SEMAINIER_WINDOWS
+  SHEET_NAME: typeof SHEET_RESERVATIONS !== 'undefined' ? SHEET_RESERVATIONS : 'Réservations',
+  STEP_MIN: typeof SEMAINIER_STEP_MIN !== 'undefined' ? SEMAINIER_STEP_MIN : 15,
+  WINDOWS: typeof SEMAINIER_WINDOWS !== 'undefined' ? SEMAINIER_WINDOWS : {}
 };
 
 // ====== API appelées par l'UI ======


### PR DESCRIPTION
## Summary
- reintroduce semainier parameter object `PB` with safe `typeof` guards for missing config

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9e2e2026083268ec839dd95eb8898