### PR TITLE
fix: restore semainier constant with safe defaults

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -254,9 +254,9 @@ function doPost(e) {
  */
 // ====== PARAMÈTRES SEMAINIER ======
 const PB = {
-  SHEET_NAME: SHEET_RESERVATIONS,
-  STEP_MIN: SEMAINIER_STEP_MIN,
-  WINDOWS: SEMAINIER_WINDOWS
+  SHEET_NAME: typeof SHEET_RESERVATIONS !== 'undefined' ? SHEET_RESERVATIONS : 'Réservations',
+  STEP_MIN: typeof SEMAINIER_STEP_MIN !== 'undefined' ? SEMAINIER_STEP_MIN : 15,
+  WINDOWS: typeof SEMAINIER_WINDOWS !== 'undefined' ? SEMAINIER_WINDOWS : {}
 };
 
 // ====== API appelées par l'UI ======

--- a/Reservation_Interface.html
+++ b/Reservation_Interface.html
@@ -308,7 +308,7 @@
     <?!= include('Script_ThemeSelector'); ?>
   <? } ?>
   <? if (THEME_V2_ENABLED) { ?>
-    
+
   <?!= include('Reservation_JS_UI'); ?>
   <?!= include('Reservation_JS_UI_Elements'); ?>
   <?!= include('Reservation_JS_Principal'); ?>
@@ -316,6 +316,7 @@
   <?!= include('Reservation_JS_Client'); ?>
   <?!= include('Reservation_JS_Tournee'); ?>
 
+  <? } ?>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- reintroduce semainier parameter object `PB` with safe `typeof` guards for missing config
- close Theme V2 conditional block to prevent `doGet` syntax error

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9e2e2026083268ec839dd95eb8898