### PR TITLE
feat: externalise secrets via Script Properties

### DIFF
--- a/Admin_Archive.gs
+++ b/Admin_Archive.gs
@@ -11,7 +11,7 @@ function archiverFacturesDuMois() {
     const debutMoisPrecedent = new Date(maintenant.getFullYear(), maintenant.getMonth() - 1, 1);
     const finMoisPrecedent = new Date(debutMoisCourant.getTime() - 24 * 60 * 60 * 1000);
 
-    const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
+    const ss = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL'));
     const feuille = ss.getSheetByName(SHEET_FACTURATION);
     if (!feuille) throw new Error("La feuille 'Facturation' est introuvable.");
     const lastCol = feuille.getLastColumn();
@@ -27,7 +27,7 @@ function archiverFacturesDuMois() {
     }
 
     const donnees = feuille.getDataRange().getValues();
-    const dossierArchives = DriveApp.getFolderById(ID_DOSSIER_ARCHIVES);
+    const dossierArchives = DriveApp.getFolderById(getSecret('ID_DOSSIER_ARCHIVES'));
     const dossierAnnee = obtenirOuCreerDossier(dossierArchives, debutMoisPrecedent.getFullYear().toString());
     const libMois = formaterDatePersonnalise(debutMoisPrecedent, "MMMM yyyy");
     const dossierMois = obtenirOuCreerDossier(dossierAnnee, libMois);

--- a/Administration.gs
+++ b/Administration.gs
@@ -25,7 +25,7 @@ function calculerCAEnCours() {
     return null;
   }
 
-  const feuille = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName(SHEET_FACTURATION);
+  const feuille = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL')).getSheetByName(SHEET_FACTURATION);
   if (!feuille) return null;
 
   const indices = obtenirIndicesEnTetes(feuille, ["Date", "Montant"]);
@@ -57,7 +57,7 @@ function obtenirToutesReservationsAdmin() {
       return { success: false, error: "Accès non autorisé." };
     }
 
-    const feuille = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName(SHEET_FACTURATION);
+    const feuille = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL')).getSheetByName(SHEET_FACTURATION);
     if (!feuille) throw new Error("La feuille 'Facturation' est introuvable.");
 
     const enTetesRequis = ["Date", "Client (Email)", "Event ID", "Détails", "Client (Raison S. Client)", "ID Réservation", "Montant", "Type Remise Appliquée", "Valeur Remise Appliquée", "Tournée Offerte Appliquée", "Statut"];
@@ -77,7 +77,7 @@ function obtenirToutesReservationsAdmin() {
         const eventId = String(ligne[indices["Event ID"]]).trim();
         if (eventId) {
           try {
-            const evenementRessource = Calendar.Events.get(ID_CALENDRIER, eventId);
+            const evenementRessource = Calendar.Events.get(getSecret('ID_CALENDRIER'), eventId);
             // On met à jour avec les infos du calendrier si elles existent, car elles sont plus précises
             dateDebutEvenement = new Date(evenementRessource.start.dateTime || evenementRessource.start.date);
             dateFinEvenement = new Date(evenementRessource.end.dateTime || evenementRessource.end.date);
@@ -151,7 +151,7 @@ function obtenirToutesReservationsPourDate(dateFiltreString) {
       return { success: false, error: "Accès non autorisé." };
     }
 
-    const feuille = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName(SHEET_FACTURATION);
+    const feuille = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL')).getSheetByName(SHEET_FACTURATION);
     if (!feuille) throw new Error("La feuille 'Facturation' est introuvable.");
 
     const enTetesRequis = ["Date", "Client (Email)", "Event ID", "Détails", "Client (Raison S. Client)", "ID Réservation", "Montant", "Type Remise Appliquée", "Valeur Remise Appliquée", "Tournée Offerte Appliquée", "Statut"];
@@ -180,7 +180,7 @@ function obtenirToutesReservationsPourDate(dateFiltreString) {
         const eventId = String(ligne[indices["Event ID"]]).trim();
         if (eventId) {
           try {
-            const evenementRessource = Calendar.Events.get(ID_CALENDRIER, eventId);
+            const evenementRessource = Calendar.Events.get(getSecret('ID_CALENDRIER'), eventId);
             dateDebutEvenement = new Date(evenementRessource.start.dateTime || evenementRessource.start.date);
             dateFinEvenement = new Date(evenementRessource.end.dateTime || evenementRessource.end.date);
           } catch (err) {
@@ -250,7 +250,7 @@ function obtenirToutesReservationsPourDate(dateFiltreString) {
  */
 function obtenirTousLesClients() {
     try {
-        const feuilleClients = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName(SHEET_CLIENTS);
+        const feuilleClients = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL')).getSheetByName(SHEET_CLIENTS);
         if (!feuilleClients) return [];
         const indices = obtenirIndicesEnTetes(feuilleClients, ["Email", "Raison Sociale", "Adresse", "SIRET", COLONNE_TYPE_REMISE_CLIENT, COLONNE_VALEUR_REMISE_CLIENT, COLONNE_NB_TOURNEES_OFFERTES]);
         const donnees = feuilleClients.getDataRange().getValues();
@@ -336,7 +336,7 @@ function creerReservationAdmin(data) {
     const titreEvenement = `Réservation ${NOM_ENTREPRISE} - ${data.client.nom}`;
     const descriptionEvenement = `Client: ${data.client.nom} (${data.client.email})\nType: ${typeCourse}\nID Réservation: ${idReservation}\nArrêts suppl: ${data.additionalStops}, Retour: ${data.returnToPharmacy ? 'Oui' : 'Non'}\nTotal: ${prix.toFixed(2)} €\nNote: Ajouté par admin.`;
 
-    const evenement = CalendarApp.getCalendarById(ID_CALENDRIER).createEvent(titreEvenement, dateDebut, dateFin, { description: descriptionEvenement });
+    const evenement = CalendarApp.getCalendarById(getSecret('ID_CALENDRIER')).createEvent(titreEvenement, dateDebut, dateFin, { description: descriptionEvenement });
 
     if (evenement) {
       const detailsFacturation = `Tournée de ${duree}min (${data.additionalStops} arrêt(s) sup., retour: ${data.returnToPharmacy ? 'oui' : 'non'})`;
@@ -381,7 +381,7 @@ function supprimerReservation(idReservation) {
       return { success: false, error: "Accès non autorisé." };
     }
 
-    const feuilleFacturation = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName(SHEET_FACTURATION);
+    const feuilleFacturation = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL')).getSheetByName(SHEET_FACTURATION);
     if (!feuilleFacturation) throw new Error("La feuille 'Facturation' est introuvable.");
 
     const enTete = feuilleFacturation.getRange(1, 1, 1, feuilleFacturation.getLastColumn()).getValues()[0];
@@ -406,7 +406,7 @@ function supprimerReservation(idReservation) {
     const montant = ligneASupprimer[indices.montant];
 
     try {
-      CalendarApp.getCalendarById(ID_CALENDRIER).getEventById(eventId).deleteEvent();
+      CalendarApp.getCalendarById(getSecret('ID_CALENDRIER')).getEventById(eventId).deleteEvent();
     } catch (e) {
       Logger.log(`Impossible de supprimer l'événement Calendar ${eventId}: ${e.message}. Il a peut-être déjà été supprimé.`);
     }
@@ -433,7 +433,7 @@ function genererFactures() {
     validerConfiguration();
     logAdminAction("Génération Factures", "Démarrée");
 
-    const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
+    const ss = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL'));
     const feuilleFacturation = ss.getSheetByName(SHEET_FACTURATION);
     const feuilleClients = ss.getSheetByName(SHEET_CLIENTS);
     const feuilleParams = ss.getSheetByName(SHEET_PARAMETRES);
@@ -511,18 +511,18 @@ function genererFactures() {
         const totalTTC = totalHT + tva;
         const dateEcheance = new Date(dateFacture.getTime() + (DELAI_PAIEMENT_JOURS * 24 * 60 * 60 * 1000));
 
-        const dossierArchives = DriveApp.getFolderById(ID_DOSSIER_ARCHIVES);
+        const dossierArchives = DriveApp.getFolderById(getSecret('ID_DOSSIER_ARCHIVES'));
         const dossierAnnee = obtenirOuCreerDossier(dossierArchives, dateFacture.getFullYear().toString());
         const dossierMois = obtenirOuCreerDossier(dossierAnnee, formaterDatePersonnalise(dateFacture, "MMMM yyyy"));
 
-        const modeleFacture = DriveApp.getFileById(ID_MODELE_FACTURE);
+        const modeleFacture = DriveApp.getFileById(getSecret('ID_MODELE_FACTURE'));
         const copieFactureDoc = modeleFacture.makeCopy(`${numFacture} - ${clientInfos.nom}`, dossierMois);
         const doc = DocumentApp.openById(copieFactureDoc.getId());
         const corps = doc.getBody();
 
         corps.replaceText('{{nom_entreprise}}', NOM_ENTREPRISE);
         corps.replaceText('{{adresse_entreprise}}', ADRESSE_ENTREPRISE);
-        corps.replaceText('{{siret}}', SIRET);
+        corps.replaceText('{{siret}}', getSecret('SIRET'));
         corps.replaceText('{{email_entreprise}}', EMAIL_ENTREPRISE);
         corps.replaceText('{{client_nom}}', clientInfos.nom);
         corps.replaceText('{{client_adresse}}', clientInfos.adresse);
@@ -535,8 +535,8 @@ function genererFactures() {
         corps.replaceText('{{montant_tva}}', tva.toFixed(2));
         corps.replaceText('{{total_ttc}}', totalTTC.toFixed(2));
         corps.replaceText('{{date_echeance}}', formaterDatePersonnalise(dateEcheance, 'dd/MM/yyyy'));
-        corps.replaceText('{{rib_entreprise}}', RIB_ENTREPRISE);
-        corps.replaceText('{{bic_entreprise}}', BIC_ENTREPRISE);
+        corps.replaceText('{{rib_entreprise}}', getSecret('RIB_ENTREPRISE'));
+        corps.replaceText('{{bic_entreprise}}', getSecret('BIC_ENTREPRISE'));
         
         const tableBordereau = trouverTableBordereau(corps);
         if (tableBordereau) {
@@ -609,7 +609,7 @@ function genererFactures() {
 function envoyerFacturesControlees() {
   const ui = SpreadsheetApp.getUi();
   try {
-    const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
+    const ss = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL'));
     const feuille = ss.getSheetByName(SHEET_FACTURATION);
     if (!feuille) throw new Error("La feuille 'Facturation' est introuvable.");
 
@@ -642,7 +642,7 @@ function archiverFacturesDuMois() {
     const debutMoisPrecedent = new Date(maintenant.getFullYear(), maintenant.getMonth() - 1, 1);
     const finMoisPrecedent = new Date(debutMoisCourant.getTime() - 24 * 60 * 60 * 1000);
 
-    const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
+    const ss = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL'));
     const feuille = ss.getSheetByName(SHEET_FACTURATION);
     if (!feuille) throw new Error("La feuille 'Facturation' est introuvable.");
 
@@ -658,7 +658,7 @@ function archiverFacturesDuMois() {
     }
 
     const donnees = feuille.getDataRange().getValues();
-    const dossierArchives = DriveApp.getFolderById(ID_DOSSIER_ARCHIVES);
+    const dossierArchives = DriveApp.getFolderById(getSecret('ID_DOSSIER_ARCHIVES'));
     const dossierAnnee = obtenirOuCreerDossier(dossierArchives, debutMoisPrecedent.getFullYear().toString());
     const libMois = formaterDatePersonnalise(debutMoisPrecedent, "MMMM yyyy");
     const dossierMois = obtenirOuCreerDossier(dossierAnnee, libMois);

--- a/Calendrier.gs
+++ b/Calendrier.gs
@@ -13,7 +13,7 @@
  */
 function obtenirEvenementsCalendrierPourPeriode(dateDebut, dateFin) {
   try {
-    const evenements = Calendar.Events.list(ID_CALENDRIER, {
+    const evenements = Calendar.Events.list(getSecret('ID_CALENDRIER'), {
       timeMin: dateDebut.toISOString(),
       timeMax: dateFin.toISOString(),
       singleEvents: true,

--- a/Configuration.gs
+++ b/Configuration.gs
@@ -13,12 +13,6 @@ const NOM_ENTREPRISE = "EL Services";
 const ADRESSE_ENTREPRISE = "255 Avenue Marcel Castie B, 83000 Toulon";
 /** @const {string} Adresse e-mail de contact de l'entreprise. */
 const EMAIL_ENTREPRISE = "elservicestoulon@gmail.com";
-/** @const {string} Numéro SIRET d'immatriculation de l'entreprise. */
-const SIRET = "48091306000020";
-/** @const {string} IBAN utilisé pour les règlements clients. */
-const RIB_ENTREPRISE = "FR7640618804760004035757187";
-/** @const {string} Code BIC correspondant au compte bancaire de l'entreprise. */
-const BIC_ENTREPRISE = "BOUSFRPPXXX";
 /** @const {string} Adresse e-mail recevant les notifications administratives. */
 const ADMIN_EMAIL = "elservicestoulon@gmail.com";
 
@@ -35,20 +29,6 @@ const DELAI_PAIEMENT_JOURS = 5;
 const ANNEES_RETENTION_FACTURES = 5;
 /** @const {number} Durée de conservation des logs d'activité (mois). */
 const MOIS_RETENTION_LOGS = 12;
-
-// --- Identifiants des services Google ---
-/** @const {string} Identifiant du calendrier Google utilisé pour les réservations. */
-const ID_CALENDRIER = "Elservicestoulon@gmail.com";
-/** @const {string} ID du document Google Docs contenant les CGV. */
-const ID_DOCUMENT_CGV = "1ze9U3k_tcS-RlhIcI8zSs2OYom2miVy8WxyxT8ktFp0";
-/** @const {string} ID de la feuille de calcul Google Sheets principale. */
-const ID_FEUILLE_CALCUL = "1-i8xBlCrl_Rrjo2FgiL33pIRjD1EFqyvU7ILPud3-r4";
-/** @const {string} ID du modèle Google Docs utilisé pour générer les factures PDF. */
-const ID_MODELE_FACTURE = "1KWDS0gmyK3qrYWJd01vGID5fBVK10xlmErjgr7lrwmU";
-/** @const {string} ID du dossier Google Drive où sont archivées les factures. */
-const ID_DOSSIER_ARCHIVES = "1UavaEsq6TkDw1QzJZ91geKyF7hrQY4S8";
-/** @const {string} ID du dossier Google Drive temporaire pour les fichiers intermédiaires. */
-const ID_DOSSIER_TEMPORAIRE = "1yDBSzTqwaUt-abT0s7Z033C2WlN1NSs6";
 
 // --- Noms des feuilles de calcul ---
 /** @const {string} Feuille contenant les données de facturation. */

--- a/FeuilleCalcul.gs
+++ b/FeuilleCalcul.gs
@@ -12,7 +12,7 @@
 function enregistrerOuMajClient(donneesClient) {
   try {
     if (!donneesClient || !donneesClient.email) return;
-    const feuilleClients = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName(SHEET_CLIENTS);
+    const feuilleClients = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL')).getSheetByName(SHEET_CLIENTS);
     if (!feuilleClients) throw new Error("La feuille 'Clients' est introuvable.");
 
     const enTetesRequis = ["Email", "Raison Sociale", "Adresse", "SIRET", COLONNE_TYPE_REMISE_CLIENT, COLONNE_VALEUR_REMISE_CLIENT, COLONNE_NB_TOURNEES_OFFERTES];
@@ -53,7 +53,7 @@ function enregistrerOuMajClient(donneesClient) {
  */
 function obtenirInfosClientParEmail(email) {
   try {
-    const feuilleClients = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName(SHEET_CLIENTS);
+    const feuilleClients = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL')).getSheetByName(SHEET_CLIENTS);
     if (!feuilleClients) return null;
 
     const enTetesRequis = ["Email", "Raison Sociale", "Adresse", "SIRET", COLONNE_TYPE_REMISE_CLIENT, COLONNE_VALEUR_REMISE_CLIENT, COLONNE_NB_TOURNEES_OFFERTES];
@@ -88,7 +88,7 @@ function decrementerTourneesOffertesClient(emailClient) {
   const lock = LockService.getScriptLock();
   if (!lock.tryLock(10000)) return;
   try {
-    const feuilleClients = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName(SHEET_CLIENTS);
+    const feuilleClients = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL')).getSheetByName(SHEET_CLIENTS);
     if (!feuilleClients) throw new Error("La feuille 'Clients' est introuvable.");
 
     const enTetesRequis = ["Email", COLONNE_NB_TOURNEES_OFFERTES];
@@ -127,7 +127,7 @@ function decrementerTourneesOffertesClient(emailClient) {
  */
 function enregistrerReservationPourFacturation(dateHeureDebut, nomClient, emailClient, type, details, montant, idEvenement, idReservation, note, tourneeOfferteAppliquee = false, typeRemiseAppliquee = '', valeurRemiseAppliquee = 0) {
   try {
-    const feuilleFacturation = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName(SHEET_FACTURATION);
+    const feuilleFacturation = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL')).getSheetByName(SHEET_FACTURATION);
     if (!feuilleFacturation) throw new Error("La feuille 'Facturation' est introuvable.");
 
     const enTetesRequis = ["Date", "Client (Raison S. Client)", "Client (Email)", "Type", "Détails", "Montant", "Statut", "Valider", "N° Facture", "Event ID", "ID Réservation", "Note Interne", "Tournée Offerte Appliquée", "Type Remise Appliquée", "Valeur Remise Appliquée", "Lien Note"];
@@ -165,7 +165,7 @@ function enregistrerReservationPourFacturation(dateHeureDebut, nomClient, emailC
  */
 function obtenirPlagesBloqueesPourDate(date) {
     try {
-        const feuillePlagesBloquees = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName(SHEET_PLAGES_BLOQUEES);
+        const feuillePlagesBloquees = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL')).getSheetByName(SHEET_PLAGES_BLOQUEES);
         if (!feuillePlagesBloquees) return [];
 
         const indices = obtenirIndicesEnTetes(feuillePlagesBloquees, ["Date", "Heure_Debut", "Heure_Fin"]);

--- a/Maintenance.gs
+++ b/Maintenance.gs
@@ -19,7 +19,7 @@
  */
 function logAdminAction(action, statut) {
   try {
-    const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
+    const ss = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL'));
     let feuilleLog = ss.getSheetByName(SHEET_ADMIN_LOGS);
     if (!feuilleLog) {
       feuilleLog = ss.insertSheet("Admin_Logs");
@@ -42,7 +42,7 @@ function logAdminAction(action, statut) {
  */
 function logActivity(idReservation, emailClient, resume, prix, statut) {
   try {
-    const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
+    const ss = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL'));
     let feuilleLog = ss.getSheetByName(SHEET_LOGS);
     if (!feuilleLog) {
       feuilleLog = ss.insertSheet("Logs");
@@ -84,7 +84,7 @@ function notifyAdminWithThrottle(typeErreur, sujet, corps) {
  * Retourne un rapport synthétique.
  */
 function verifierStructureFeuilles() {
-  const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
+  const ss = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL'));
   const expectations = [
     { name: 'Clients', headers: ['Email', 'Raison Sociale', 'Adresse', 'SIRET', COLONNE_TYPE_REMISE_CLIENT, COLONNE_VALEUR_REMISE_CLIENT, COLONNE_NB_TOURNEES_OFFERTES], required: true },
     { name: 'Facturation', headers: ['Date', 'Client (Raison S. Client)', 'Client (Email)', 'Type', 'Détails', 'Montant', 'Statut', 'Valider', 'N° Facture', 'Event ID', 'ID Réservation', 'Note Interne', 'Tournée Offerte Appliquée', 'Type Remise Appliquée', 'Valeur Remise Appliquée', 'Lien Note'], required: true },
@@ -176,7 +176,7 @@ function sauvegarderCodeProjet() {
     const horodatage = formaterDatePersonnalise(new Date(), "yyyy-MM-dd'_'HH'h'mm");
     const nomDossierSauvegarde = `Sauvegarde Code ${horodatage}`;
     
-    const dossierProjet = DriveApp.getFileById(ID_FEUILLE_CALCUL).getParents().next();
+    const dossierProjet = DriveApp.getFileById(getSecret('ID_FEUILLE_CALCUL')).getParents().next();
     const dossierParentSauvegardes = obtenirOuCreerDossier(dossierProjet, "Sauvegardes Code");
     const dossierSauvegarde = dossierParentSauvegardes.createFolder(nomDossierSauvegarde);
     
@@ -201,9 +201,9 @@ function sauvegarderDonnees() {
   logAdminAction("Sauvegarde des données", "Démarré");
   try {
     const feuillesASauvegarder = ["Clients", "Facturation", "Plages_Bloquees", "Logs", "Admin_Logs"];
-    const ssOriginale = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
+    const ssOriginale = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL'));
     
-    const dossierProjet = DriveApp.getFileById(ID_FEUILLE_CALCUL).getParents().next();
+    const dossierProjet = DriveApp.getFileById(getSecret('ID_FEUILLE_CALCUL')).getParents().next();
     const dossierParentSauvegardes = obtenirOuCreerDossier(dossierProjet, "Sauvegardes Données");
 
     const horodatage = formaterDatePersonnalise(new Date(), "yyyy-MM-dd");
@@ -260,7 +260,7 @@ function recupererTousLesFichiersProjet() {
 function purgerAnciennesDonnees() {
   logAdminAction("Purge RGPD (Données + Fichiers)", "Démarré");
   try {
-    const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
+    const ss = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL'));
     
     // --- Purge de la feuille de facturation et des PDF ---
     const feuilleFacturation = ss.getSheetByName(SHEET_FACTURATION);
@@ -344,7 +344,7 @@ function purgerDonneesFeuille(feuille, indexColonneDate, indexColonneIdFichier, 
 function nettoyerOngletFacturation() {
   const ui = SpreadsheetApp.getUi();
   try {
-    const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
+    const ss = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL'));
     const feuille = ss.getSheetByName(SHEET_FACTURATION);
     if (!feuille) throw new Error("La feuille 'Facturation' est introuvable.");
 
@@ -498,7 +498,7 @@ function nettoyerOngletFacturation() {
 function reparerEntetesFacturation() {
   const ui = SpreadsheetApp.getUi();
   try {
-    const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
+    const ss = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL'));
     const sh = ss.getSheetByName(SHEET_FACTURATION);
     if (!sh) throw new Error("Feuille 'Facturation' introuvable.");
     const lastCol = sh.getLastColumn();
@@ -590,7 +590,7 @@ function reparerEntetesFacturation() {
  * - Réordonne les colonnes selon la liste de référence
  */
 function normaliserEntetesFacturation() {
-  const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
+  const ss = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL'));
   const sh = ss.getSheetByName(SHEET_FACTURATION);
   if (!sh) throw new Error("Feuille 'Facturation' introuvable.");
 
@@ -677,7 +677,7 @@ function resynchroniserEvenement(idReservation) {
     throw new Error('Resynchronisation désactivée.');
   }
   try {
-    const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
+    const ss = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL'));
     const feuille = ss.getSheetByName(SHEET_FACTURATION);
     if (!feuille) throw new Error("La feuille 'Facturation' est introuvable.");
 
@@ -732,7 +732,7 @@ function purgerEventIdInexistant(idReservation) {
     throw new Error('Purge désactivée.');
   }
   try {
-    const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
+    const ss = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL'));
     const feuille = ss.getSheetByName(SHEET_FACTURATION);
     if (!feuille) throw new Error("La feuille 'Facturation' est introuvable.");
 
@@ -750,7 +750,7 @@ function purgerEventIdInexistant(idReservation) {
     }
 
     try {
-      Calendar.Events.get(ID_CALENDRIER, eventId);
+      Calendar.Events.get(getSecret('ID_CALENDRIER'), eventId);
       logAdminAction('Purge Event ID', `Annulé: événement existe (${idReservation})`);
       return false;
     } catch (e) {
@@ -783,7 +783,7 @@ function verifierCoherenceCalendrier() {
   logAdminAction("Vérification Cohérence Calendrier", "Démarré");
 
   try {
-    const ss = SpreadsheetApp.openById(ID_FEUILLE_CALCUL);
+    const ss = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL'));
     const feuille = ss.getSheetByName(SHEET_FACTURATION);
     if (!feuille) throw new Error("La feuille 'Facturation' est introuvable.");
 
@@ -808,7 +808,7 @@ function verifierCoherenceCalendrier() {
       }
 
       try {
-        const evenement = Calendar.Events.get(ID_CALENDRIER, eventId);
+        const evenement = Calendar.Events.get(getSecret('ID_CALENDRIER'), eventId);
         const dateCalendrier = new Date(evenement.start.dateTime || evenement.start.date);
         
         if (dateSheet.getFullYear() !== dateCalendrier.getFullYear() ||

--- a/README.md
+++ b/README.md
@@ -80,10 +80,16 @@ Si un événement supprimé ne doit pas être recréé, on peut purger sa réfé
 4. Désactiver le flag une fois l'opération terminée.
 
 ## Script Properties
-Define these keys in the Apps Script project via `PropertiesService`:
+Set the following keys in the Apps Script editor (File → Project properties → Script properties):
 
-- `ADRESSE_ENTREPRISE`
+- `SIRET`
 - `RIB_ENTREPRISE`
 - `BIC_ENTREPRISE`
+- `ID_CALENDRIER`
+- `ID_DOCUMENT_CGV`
+- `ID_FEUILLE_CALCUL`
+- `ID_MODELE_FACTURE`
+- `ID_DOSSIER_ARCHIVES`
+- `ID_DOSSIER_TEMPORAIRE`
 
-Run `initScriptProperties()` in `Configuration.gs` to populate default values.
+Open the Apps Script editor, go to **File → Project properties → Script properties**, and add each key with its value.

--- a/Reservation.gs
+++ b/Reservation.gs
@@ -77,7 +77,7 @@ function creerReservationUnique(item, client, clientPourCalcul, options = {}) {
 
     const titreEvenement = `Réservation ${NOM_ENTREPRISE} - ${client.nom}`;
     const descriptionEvenement = `Client: ${client.nom} (${client.email})\nID Réservation: ${idReservation}\nDétails: ${infosTournee.details}\nNote: ${client.note || ''}`;
-    const evenement = CalendarApp.getCalendarById(ID_CALENDRIER).createEvent(titreEvenement, dateDebut, dateFin, { description: descriptionEvenement });
+    const evenement = CalendarApp.getCalendarById(getSecret('ID_CALENDRIER')).createEvent(titreEvenement, dateDebut, dateFin, { description: descriptionEvenement });
 
     if (evenement) {
         const infosPrixFinal = calculerPrixEtDureeServeur(totalStops, returnToPharmacy, date, startTime, clientPourCalcul);
@@ -326,7 +326,7 @@ function trouverAlternativeProche(creneauCible, creneauxDisponibles) {
  * Récupère toutes les réservations pour un email client (et optionnellement une date).
  */
 function obtenirReservationsPourClient(email, date) {
-  var sheet = SpreadsheetApp.openById(ID_FEUILLE_CALCUL).getSheetByName(SHEET_FACTURATION);
+  var sheet = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL')).getSheetByName(SHEET_FACTURATION);
   var data = sheet.getDataRange().getValues();
   var headers = data[0];
   var emailIndex = headers.indexOf("Client (Email)");

--- a/Utilitaires.gs
+++ b/Utilitaires.gs
@@ -151,6 +151,24 @@ function setUserTheme(theme) {
 }
 
 /**
+ * Récupère un secret depuis les Script Properties.
+ * @param {string} name Nom de la propriété.
+ * @returns {string|null} Valeur du secret.
+ */
+function getSecret(name) {
+  return PropertiesService.getScriptProperties().getProperty(name);
+}
+
+/**
+ * Enregistre un secret dans les Script Properties.
+ * @param {string} name Nom de la propriété.
+ * @param {string} value Valeur à stocker.
+ */
+function setSecret(name, value) {
+  PropertiesService.getScriptProperties().setProperty(name, value);
+}
+
+/**
  * Retourne les flags d'activation pour le client.
  * @returns {Object} Flags configurables depuis Configuration.gs.
  */

--- a/Validation.gs
+++ b/Validation.gs
@@ -19,8 +19,9 @@ function validerConfiguration() {
     erreurs.push(`Format de l'e-mail administrateur invalide : ${ADMIN_EMAIL}`);
   }
   
-  if (!/^\d{14}$/.test(SIRET)) {
-    erreurs.push(`Format du SIRET invalide. Il doit contenir 14 chiffres. Valeur actuelle : ${SIRET}`);
+  const siret = getSecret('SIRET');
+  if (!/^\d{14}$/.test(siret)) {
+    erreurs.push(`Format du SIRET invalide. Il doit contenir 14 chiffres. Valeur actuelle : ${siret}`);
   }
   
   // --- Vérification de la cohérence ---
@@ -29,12 +30,12 @@ function validerConfiguration() {
   }
 
   // --- Test d'accès aux IDs des services Google ---
-  try { DriveApp.getFolderById(ID_DOSSIER_ARCHIVES); } catch (e) { erreurs.push("L'ID du dossier d'archives (ID_DOSSIER_ARCHIVES) est invalide ou l'accès est refusé."); }
-  try { DriveApp.getFolderById(ID_DOSSIER_TEMPORAIRE); } catch (e) { erreurs.push("L'ID du dossier temporaire (ID_DOSSIER_TEMPORAIRE) est invalide ou l'accès est refusé."); }
-  try { DocumentApp.openById(ID_MODELE_FACTURE); } catch (e) { erreurs.push("L'ID du modèle de facture (ID_MODELE_FACTURE) est invalide ou l'accès est refusé."); }
-  try { SpreadsheetApp.openById(ID_FEUILLE_CALCUL); } catch (e) { erreurs.push("L'ID de la feuille de calcul (ID_FEUILLE_CALCUL) est invalide ou l'accès est refusé."); }
-  try { DocumentApp.openById(ID_DOCUMENT_CGV); } catch (e) { erreurs.push("L'ID du document des CGV (ID_DOCUMENT_CGV) est invalide ou l'accès est refusé."); }
-  try { CalendarApp.getCalendarById(ID_CALENDRIER); } catch (e) { erreurs.push("L'ID du calendrier (ID_CALENDRIER) est invalide ou l'accès est refusé."); }
+  try { DriveApp.getFolderById(getSecret('ID_DOSSIER_ARCHIVES')); } catch (e) { erreurs.push("L'ID du dossier d'archives (ID_DOSSIER_ARCHIVES) est invalide ou l'accès est refusé."); }
+  try { DriveApp.getFolderById(getSecret('ID_DOSSIER_TEMPORAIRE')); } catch (e) { erreurs.push("L'ID du dossier temporaire (ID_DOSSIER_TEMPORAIRE) est invalide ou l'accès est refusé."); }
+  try { DocumentApp.openById(getSecret('ID_MODELE_FACTURE')); } catch (e) { erreurs.push("L'ID du modèle de facture (ID_MODELE_FACTURE) est invalide ou l'accès est refusé."); }
+  try { SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL')); } catch (e) { erreurs.push("L'ID de la feuille de calcul (ID_FEUILLE_CALCUL) est invalide ou l'accès est refusé."); }
+  try { DocumentApp.openById(getSecret('ID_DOCUMENT_CGV')); } catch (e) { erreurs.push("L'ID du document des CGV (ID_DOCUMENT_CGV) est invalide ou l'accès est refusé."); }
+  try { CalendarApp.getCalendarById(getSecret('ID_CALENDRIER')); } catch (e) { erreurs.push("L'ID du calendrier (ID_CALENDRIER) est invalide ou l'accès est refusé."); }
 
   // --- Gestion centralisée des erreurs ---
   if (erreurs.length > 0) {


### PR DESCRIPTION
## Summary
- add helpers to read/write Script Properties
- load SIRET and Google service IDs from Script Properties rather than constants
- document required Script Property keys

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9f636337c8326a86461da330703b9