### PR TITLE
feat: enforce shared secret on web endpoints

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -74,6 +74,7 @@ function creerReponseHtml(titre, message) {
  */
 function doGet(e) {
   try {
+    checkSharedSecret(e);
     if (typeof REQUEST_LOGGING_ENABLED !== 'undefined' && REQUEST_LOGGING_ENABLED) {
       logRequest(e); // Assurez-vous que la fonction logRequest existe
     }
@@ -168,6 +169,10 @@ function doGet(e) {
       .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.DEFAULT);
 
   } catch (error) {
+    if (error && error.code === 403) {
+      return ContentService.createTextOutput(JSON.stringify({ error: 'Forbidden' }))
+        .setMimeType(ContentService.MimeType.JSON);
+    }
     Logger.log(`Erreur critique dans doGet: ${error.stack}`);
     return creerReponseHtml(
       'Erreur de configuration',
@@ -185,6 +190,7 @@ function doGet(e) {
  */
 function doPost(e) {
   try {
+    checkSharedSecret(e);
     if (typeof REQUEST_LOGGING_ENABLED !== 'undefined' && REQUEST_LOGGING_ENABLED) {
       logRequest(e);
     }
@@ -239,6 +245,10 @@ function doPost(e) {
     })).setMimeType(ContentService.MimeType.JSON);
 
   } catch (error) {
+    if (error && error.code === 403) {
+      return ContentService.createTextOutput(JSON.stringify({ error: 'Forbidden' }))
+        .setMimeType(ContentService.MimeType.JSON);
+    }
     Logger.log(`Erreur critique dans doPost: ${error.stack}`);
     return ContentService.createTextOutput(JSON.stringify({
       status: 'error',

--- a/README.md
+++ b/README.md
@@ -96,9 +96,11 @@ Set the following keys in the Apps Script editor (File → Project properties �
 Open the Apps Script editor, go to **File → Project properties → Script properties**, and add each key with its value.
 
 ## Authentification des requêtes
-Toutes les requêtes vers la web app doivent fournir le jeton défini dans `ELS_SHARED_SECRET`.
+Les fonctions `doGet` et `doPost` appellent `checkSharedSecret(e)` pour valider le jeton stocké dans `ELS_SHARED_SECRET`.
+
+Fournissez ce jeton :
 
 - En-tête HTTP `X-ELS-TOKEN: <votre_jeton>`
-- ou paramètre `token=<votre_jeton>` / `X-ELS-TOKEN=<votre_jeton>` dans l'URL ou le corps
+- ou paramètre `token=<votre_jeton>` dans l'URL ou le corps
 
-Les requêtes sans jeton valide reçoivent une réponse JSON `403`.
+Sans jeton valide, la web app renvoie `{"error":"Forbidden"}`.

--- a/Utilitaires.gs
+++ b/Utilitaires.gs
@@ -169,6 +169,22 @@ function setSecret(name, value) {
 }
 
 /**
+ * Vérifie le jeton partagé fourni dans la requête.
+ * @param {Object} e Objet d'événement de la requête.
+ * @throws {Error} Erreur 403 si le jeton est absent ou invalide.
+ */
+function checkSharedSecret(e) {
+  const expected = getSecret('ELS_SHARED_SECRET');
+  const token = (e && e.parameter && e.parameter.token) ||
+    (e && e.headers && e.headers['X-ELS-TOKEN']);
+  if (!token || !expected || token !== expected) {
+    const err = new Error('Forbidden');
+    err.code = 403;
+    throw err;
+  }
+}
+
+/**
  * Retourne les flags d'activation pour le client.
  * @returns {Object} Flags configurables depuis Configuration.gs.
  */


### PR DESCRIPTION
## Summary
- add `checkSharedSecret` utility validating `ELS_SHARED_SECRET`
- protect `doGet` and `doPost` by checking shared token
- document token usage in README

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba826e6d548326b0ac262d31d700f4