### PR TITLE
feat: enrich reservation head with SEO metadata

### DIFF
--- a/Maintenance.gs
+++ b/Maintenance.gs
@@ -831,7 +831,7 @@ function verifierCoherenceCalendrier() {
     rapportHtml += `<p><strong>${reservationsVerifiees}</strong> réservations ont été analysées.</p>`;
 
     if (incoherences.length === 0) {
-      rapportHtml += `<p style="color: green;"><strong>Aucune incohérence trouvée.</strong> Tout est synchronisé !</p>`;
+      rapportHtml += `<p style="color: #2b76c6;"><strong>Aucune incohérence trouvée.</strong> Tout est synchronisé !</p>`;
     } else {
       rapportHtml += `<p style="color: red;"><strong>${incoherences.length} incohérence(s) détectée(s) :</strong></p>`;
       rapportHtml += `<pre>${incoherences.join('<br>')}</pre>`;

--- a/Reservation_Interface.html
+++ b/Reservation_Interface.html
@@ -5,6 +5,62 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Permissions-Policy" content="camera=(), microphone=()" />
+  <meta name="description" content="Livraison pharmacie à domicile et EHPAD sur Tamaris, Mar Vivo, Six-Fours-les-Plages, Sanary, Portissol et Bandol.">
+  <link rel="canonical" href="<?= appUrl ?>">
+  <meta property="og:title" content="<?= nomService ?> | Livraison Pharmacie Tamaris, Mar Vivo, Six-Fours">
+  <meta property="og:description" content="Réservez vos tournées de livraison de pharmacie à domicile sur Tamaris, Mar Vivo, Six-Fours, Sanary, Portissol et Bandol.">
+  <meta property="og:url" content="<?= appUrl ?>">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="<?= nomService ?> | Livraison Pharmacie Tamaris, Mar Vivo, Six-Fours">
+  <meta name="twitter:description" content="Réservez vos tournées de livraison de pharmacie à domicile sur Tamaris, Mar Vivo, Six-Fours, Sanary, Portissol et Bandol.">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "LocalBusiness",
+        "@id": "<?= appUrl ?>#business",
+        "name": "<?= nomService ?>",
+        "description": "Livraison pharmacie à domicile et EHPAD sur Tamaris, Mar Vivo, Six-Fours-les-Plages, Sanary, Portissol et Bandol.",
+        "url": "<?= appUrl ?>",
+        "email": "elservicestoulon@gmail.com",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Six-Fours-les-Plages",
+          "addressCountry": "FR"
+        },
+        "geo": {
+          "@type": "GeoCoordinates",
+          "latitude": 43.0842,
+          "longitude": 5.8009
+        },
+        "areaServed": [
+          { "@type": "Place", "name": "Tamaris" },
+          { "@type": "Place", "name": "Mar Vivo" },
+          { "@type": "Place", "name": "Six-Fours-les-Plages" },
+          { "@type": "Place", "name": "Sanary" },
+          { "@type": "Place", "name": "Portissol" },
+          { "@type": "Place", "name": "Bandol" }
+        ]
+      },
+      {
+        "@type": "Service",
+        "@id": "<?= appUrl ?>#service",
+        "serviceType": "Livraison de pharmacie",
+        "provider": { "@id": "<?= appUrl ?>#business" },
+        "areaServed": [
+          { "@type": "Place", "name": "Tamaris" },
+          { "@type": "Place", "name": "Mar Vivo" },
+          { "@type": "Place", "name": "Six-Fours-les-Plages" },
+          { "@type": "Place", "name": "Sanary" },
+          { "@type": "Place", "name": "Portissol" },
+          { "@type": "Place", "name": "Bandol" }
+        ]
+      }
+    ]
+  }
+  </script>
   <title><?= nomService ?> | Réservation de Livraison</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- add targeted meta, OG and Twitter tags for reservation interface
- inject LocalBusiness and Service JSON-LD
- replace green success text with compliant blue

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba84dbc5048326b3162658f720ab9b