### PR TITLE
Remove legacy UI shim

### DIFF
--- a/Reservation_JS_UI.html
+++ b/Reservation_JS_UI.html
@@ -1,22 +1,5 @@
 <script>
   const SEMAINIER_ENABLED = <?= SEMAINIER_ENABLED ?>;
-  /**
-   * LEGACY SHIM — TODO: remove once all deployments use the new UI.
-   * Provides inert stubs for legacy global initializers and overwrites
-   * any existing implementations to prevent side effects.
-   */
-  (function (global) {
-    [
-      'basculerIndicateurChargement',
-      'initialiser',
-      'initialiserInterface',
-      'initCalendrier',
-      'initPanier',
-      'initReservation'
-    ].forEach(function (name) {
-      global[name] = function () {};
-    });
-  })(this);
 </script>
 <style>
     :root{


### PR DESCRIPTION
## Summary
- remove legacy shim block from Reservation_JS_UI
- confirm all interfaces use Reservation_JS_UI and no legacy init functions remain

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba8cb865e08326b0dc08f54ea7e117