### PR TITLE
fix: externalise entreprise secrets [no-structure-change]

### DIFF
--- a/Configuration.gs
+++ b/Configuration.gs
@@ -8,13 +8,13 @@
 
 // --- Informations sur l'entreprise ---
 /** @const {string} Nom officiel de l'entreprise utilisé dans l'interface et la facturation. */
-const NOM_ENTREPRISE = "EL Services";
+const NOM_ENTREPRISE = getSecret('NOM_ENTREPRISE');
 /** @const {string} Adresse postale de l'entreprise pour les documents légaux. */
-const ADRESSE_ENTREPRISE = "255 Avenue Marcel Castie B, 83000 Toulon";
+const ADRESSE_ENTREPRISE = getSecret('ADRESSE_ENTREPRISE');
 /** @const {string} Adresse e-mail de contact de l'entreprise. */
-const EMAIL_ENTREPRISE = "elservicestoulon@gmail.com";
+const EMAIL_ENTREPRISE = getSecret('EMAIL_ENTREPRISE');
 /** @const {string} Adresse e-mail recevant les notifications administratives. */
-const ADMIN_EMAIL = "elservicestoulon@gmail.com";
+const ADMIN_EMAIL = getSecret('ADMIN_EMAIL');
 
 // --- Paramètres de facturation ---
 /** @const {boolean} Indique si la TVA est appliquée ; désactivé par défaut. */

--- a/Utilitaires.gs
+++ b/Utilitaires.gs
@@ -153,10 +153,15 @@ function setUserTheme(theme) {
 /**
  * Récupère un secret depuis les Script Properties.
  * @param {string} name Nom de la propriété.
- * @returns {string|null} Valeur du secret.
+ * @returns {string} Valeur du secret.
+ * @throws {Error} Si la propriété est absente.
  */
 function getSecret(name) {
-  return PropertiesService.getScriptProperties().getProperty(name);
+  const value = PropertiesService.getScriptProperties().getProperty(name);
+  if (value === null || value === '') {
+    throw new Error(`Propriété manquante: ${name}`);
+  }
+  return value;
 }
 
 /**


### PR DESCRIPTION
## Summary
- fetch enterprise identifiers from Script Properties via getSecret
- ensure getSecret throws explicit error when a property is missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bacdc9cb388326bf34762fddf6592b