### PR TITLE
Reservation: ajoute afficherConteneurFinalisation

### DIFF
--- a/Reservation_JS_Principal.html
+++ b/Reservation_JS_Principal.html
@@ -54,6 +54,32 @@ function afficherErreur(erreur) {
 }
 
 /**
+ * Affiche le conteneur de finalisation et pré-remplit les champs client.
+ */
+function afficherConteneurFinalisation() {
+  const { ui } = window;
+  const { clientReconnu, flags } = window.etat;
+
+  if (flags && flags.clientPortalEnabled === false) return;
+
+  if (clientReconnu) {
+    ui.champEmailClient.value = clientReconnu.email;
+    ui.champNomClient.value = clientReconnu.nom;
+    ui.champAdresseClient.value = clientReconnu.adresse || '';
+    ui.champSiretClient.value = clientReconnu.siret || '';
+    ui.champEmailClient.readOnly = true;
+    ui.champNomClient.readOnly = true;
+  } else {
+    if (ui.formulaireReservation) ui.formulaireReservation.reset();
+    ui.champEmailClient.readOnly = false;
+    ui.champNomClient.readOnly = false;
+  }
+
+  ui.conteneurFinalisation.classList.remove('hidden');
+  ui.champEmailClient.focus();
+}
+
+/**
  * Configure tous les écouteurs d'événements de l'application.
  */
 function configurerEcouteursEvenements() {

--- a/Utilitaires.gs
+++ b/Utilitaires.gs
@@ -241,6 +241,7 @@ function checkSharedSecret(e) {
  */
 function getConfiguration() {
   return {
+    clientPortalEnabled: CLIENT_PORTAL_ENABLED,
     slotsAmpmEnabled: SLOTS_AMPM_ENABLED,
     semainierEnabled: SEMAINIER_ENABLED,
     themeV2Enabled: THEME_V2_ENABLED,


### PR DESCRIPTION
## Summary
- add afficherConteneurFinalisation to populate client fields and open finalization container
- expose clientPortalEnabled flag to client config

## Testing
- `npm test`
- `npm run test:clasp` *(fails: unknown option '--noninteractive')*

------
https://chatgpt.com/codex/tasks/task_e_68bad45cb8588326b26d52f1cea6230a