### PR TITLE
Use configuration email in reservation structured data

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -197,6 +197,7 @@ function doGet(e) {
     template.THEME_SELECTION_ENABLED = THEME_SELECTION_ENABLED;
     template.appUrl = ScriptApp.getService().getUrl();
     template.nomService = NOM_ENTREPRISE;
+    template.EMAIL_ENTREPRISE = EMAIL_ENTREPRISE;
     template.CLIENT_PORTAL_ENABLED = CLIENT_PORTAL_ENABLED;
     template.TARIFS_JSON = JSON.stringify(conf.TARIFS || {});
     template.TARIFS = conf.TARIFS;

--- a/Reservation_Interface.html
+++ b/Reservation_Interface.html
@@ -24,7 +24,7 @@
         "name": "<?= nomService ?>",
         "description": "Livraison pharmacie à domicile et EHPAD sur Tamaris, Mar Vivo, Six-Fours-les-Plages, Sanary, Portissol et Bandol.",
         "url": "<?= appUrl ?>",
-        "email": "elservicestoulon@gmail.com",
+        "email": "<?= EMAIL_ENTREPRISE ?>",
         "address": {
           "@type": "PostalAddress",
           "addressLocality": "Six-Fours-les-Plages",


### PR DESCRIPTION
## Summary
- Inject `EMAIL_ENTREPRISE` into reservation page JSON-LD and expose it from server template

## Testing
- `node -e "const fs=require('fs');let html=fs.readFileSync('Reservation_Interface.html','utf8');html=html.replace(/<\?= EMAIL_ENTREPRISE \?>/g,'test@example.com');const match=html.match(/<script type=\"application\/ld\+json\">\n\s*({[\s\S]*?})\n\s*<\/script>/);if(match){const data=JSON.parse(match[1]);console.log('Extracted email:',data['@graph'][0].email);}else{console.error('JSON-LD block not found');}"`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bad55557688326a90d4b8ffb45dfeb