### PR TITLE
chore: remove shared secret guards

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -112,10 +112,6 @@ function creerReponseHtml(titre, message) {
 function doGet(e) {
   try {
     const page = (e && e.parameter && e.parameter.page) ? String(e.parameter.page) : '';
-    // N'exige le jeton que pour les pages sensibles
-    if (page === 'admin' || page === 'debug') {
-      checkSharedSecret(e);
-    }
     if (typeof REQUEST_LOGGING_ENABLED !== 'undefined' && REQUEST_LOGGING_ENABLED) {
       logRequest(e); // Assurez-vous que la fonction logRequest existe
     }
@@ -242,7 +238,6 @@ function doGet(e) {
  */
 function doPost(e) {
   try {
-    checkSharedSecret(e);
     if (typeof REQUEST_LOGGING_ENABLED !== 'undefined' && REQUEST_LOGGING_ENABLED) {
       logRequest(e);
     }

--- a/README.md
+++ b/README.md
@@ -95,16 +95,7 @@ Set the following keys in the Apps Script editor (File → Project properties �
 - `ID_DOSSIER_TEMPORAIRE` – dossier Drive temporaire pour génération des PDF
 - `ID_FEUILLE_CALCUL` – feuille de calcul principale
 - `ID_CALENDRIER` – calendrier Google utilisé pour les créneaux
-- `ELS_SHARED_SECRET` – jeton partagé pour l'authentification des requêtes
+- `ELS_SHARED_SECRET` – clé secrète pour signer les liens d'accès à l'espace client
 
 Open the Apps Script editor, go to **File → Project properties → Script properties**, and add each key with its value.
 
-## Authentification des requêtes
-Les fonctions `doGet` et `doPost` appellent `checkSharedSecret(e)` pour valider le jeton stocké dans `ELS_SHARED_SECRET`.
-
-Fournissez ce jeton :
-
-- En-tête HTTP `X-ELS-TOKEN: <votre_jeton>`
-- ou paramètre `token=<votre_jeton>` dans l'URL ou le corps
-
-Sans jeton valide, la web app renvoie `{"error":"Forbidden"}`.

--- a/Utilitaires.gs
+++ b/Utilitaires.gs
@@ -218,23 +218,6 @@ function generateSignedClientLink(email, ttlSeconds) {
   const url = `${baseUrl}?page=gestion&email=${encodeURIComponent(email)}&exp=${exp}&sig=${encodeURIComponent(sig)}`;
   return { url: url, exp: exp };
 }
-
-/**
- * Vérifie le jeton partagé fourni dans la requête.
- * @param {Object} e Objet d'événement de la requête.
- * @throws {Error} Erreur 403 si le jeton est absent ou invalide.
- */
-function checkSharedSecret(e) {
-  const expected = getSecret('ELS_SHARED_SECRET');
-  const token = (e && e.parameter && e.parameter.token) ||
-    (e && e.headers && e.headers['X-ELS-TOKEN']);
-  if (!token || !expected || token !== expected) {
-    const err = new Error('Forbidden');
-    err.code = 403;
-    throw err;
-  }
-}
-
 /**
  * Retourne les flags d'activation pour le client.
  * @returns {Object} Flags configurables depuis Configuration.gs.


### PR DESCRIPTION
## Summary
- remove shared secret validation from web entry points
- drop unused secret guard utility and update README accordingly

## Testing
- `npm test`
- `npm run test:clasp` *(fails: unknown option '--noninteractive')*

------
https://chatgpt.com/codex/tasks/task_e_68bae82379b8832681130adff3d02b52