### PR TITLE
fix: unifie calcul prix par arrêts totaux

### DIFF
--- a/Admin_JS.html
+++ b/Admin_JS.html
@@ -312,7 +312,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 <div class="groupe-formulaire hidden" id="conteneur-nb-tournees-offertes"><label for="nb-tournees-offertes">Nombre Tournées Offertes</label><input type="number" id="nb-tournees-offertes" class="champ-formulaire" min="0" step="1"></div>
             </div>
             <div class="groupe-formulaire"><label for="champ-date-ajout">Date de la course</label><input type="date" id="champ-date-ajout" class="champ-formulaire" value="${escapeHTML(champDate ? champDate.value : '')}"></div>
-            <div class="groupe-formulaire"><label>Arrêts supplémentaires :</label><div style="display: flex; align-items: center; gap: 20px;"><div class="champ-compteur"><button type="button" class="btn-compteur btn-retirer">-</button><span class="valeur-compteur">0</span><button type="button" class="btn-compteur btn-ajouter">+</button></div><label><input type="checkbox" id="check-retour"> Retour pharmacie</label></div></div>
+            <div class="groupe-formulaire"><label>Arrêts totaux :</label><div style="display: flex; align-items: center; gap: 20px;"><div class="champ-compteur"><button type="button" class="btn-compteur btn-retirer">-</button><span class="valeur-compteur">1</span><button type="button" class="btn-compteur btn-ajouter">+</button></div><label><input type="checkbox" id="check-retour"> Retour pharmacie</label></div></div>
             <div id="conteneur-creneaux-ajout" class="hidden"><label>Créneau disponible</label><div id="grille-creneaux-ajout"></div></div>
             <div class="modale-pied-de-page">
               <label><input type="checkbox" id="check-urgent"> Forcer urgent</label>
@@ -325,20 +325,21 @@ document.addEventListener('DOMContentLoaded', () => {
     function ouvrirModaleAjoutArret(idReservation) {
         const reservation = toutesLesReservationsAffichees.find(r => r.id === idReservation);
         if (!reservation) return afficherErreur("Réservation introuvable.");
-        const match = reservation.details.match(/(\d+)\s*arrêt\(s\)\s*sup/);
-        const arretsActuels = match ? parseInt(match[1], 10) : 0;
+        const matchTotal = reservation.details.match(/(\d+)\s*arrêt\(s\)\s*total\(s\)/);
+        const matchSup = reservation.details.match(/(\d+)\s*arrêt\(s\)\s*sup/);
+        const arretsActuels = matchTotal ? parseInt(matchTotal[1], 10) : (matchSup ? parseInt(matchSup[1], 10) + 1 : 1);
         if (!contenuModale) return;
         renderHTML(contenuModale, `
             <h3 id="modale-titre">Modifier les arrêts</h3><p><strong>Client :</strong> ${escapeHTML(reservation.clientName)}</p>
-            <div class="groupe-formulaire"><label>Nombre d'arrêts supplémentaires :</label><div class="champ-compteur"><button type="button" class="btn-compteur btn-retirer">-</button><span class="valeur-compteur">${escapeHTML(String(arretsActuels))}</span><button type="button" class="btn-compteur btn-ajouter">+</button></div></div>
+            <div class="groupe-formulaire"><label>Nombre d'arrêt(s) total(s) :</label><div class="champ-compteur"><button type="button" class="btn-compteur btn-retirer">-</button><span class="valeur-compteur">${escapeHTML(String(arretsActuels))}</span><button type="button" class="btn-compteur btn-ajouter">+</button></div></div>
             <div class="modale-pied-de-page"><button type="button" id="btn-confirmer-maj" class="btn btn-primaire">Valider la modification</button></div>`);
         if (modale) modale.classList.remove('hidden');
         const valeurCompteur = contenuModale.querySelector('.valeur-compteur');
         if (valeurCompteur) {
             contenuModale.querySelector('.btn-ajouter')?.addEventListener('click', () => { valeurCompteur.textContent = parseInt(valeurCompteur.textContent, 10) + 1; });
-            contenuModale.querySelector('.btn-retirer')?.addEventListener('click', () => { let val = parseInt(valeurCompteur.textContent, 10); if (val > 0) valeurCompteur.textContent = val - 1; });
+            contenuModale.querySelector('.btn-retirer')?.addEventListener('click', () => { let val = parseInt(valeurCompteur.textContent, 10); if (val > 1) valeurCompteur.textContent = val - 1; });
         }
-        contenuModale.querySelector('#btn-confirmer-maj')?.addEventListener('click', () => { gererSoumissionMiseAJour(idReservation, parseInt(valeurCompteur?.textContent || '0', 10)); });
+        contenuModale.querySelector('#btn-confirmer-maj')?.addEventListener('click', () => { gererSoumissionMiseAJour(idReservation, parseInt(valeurCompteur?.textContent || '1', 10)); });
     }
     function ouvrirModaleReplanifier(idReservation) {
         const reservation = toutesLesReservationsAffichees.find(r => r.id === idReservation);
@@ -427,7 +428,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // --- SOUMISSIONS (utilisent maintenant rafraichirVueActuelle) ---
-    function gererSoumissionMiseAJour(idReservation, nouveauxArrets) {
+    function gererSoumissionMiseAJour(idReservation, totalStops) {
         basculerIndicateurChargement(true);
         modale?.classList.add('hidden');
         google.script.run.withSuccessHandler(reponse => {
@@ -436,7 +437,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 afficherNotification("Réservation mise à jour !", "succes");
                 rafraichirVueActuelle();
             } else { afficherErreur(reponse.error); }
-        }).withFailureHandler(afficherErreur).mettreAJourDetailsReservation(idReservation, nouveauxArrets);
+        }).withFailureHandler(afficherErreur).mettreAJourDetailsReservation(idReservation, totalStops);
     }
     function gererSoumissionReplanifier(idReservation, nouvelleDate, nouvelleHeure) {
         basculerIndicateurChargement(true);
@@ -517,15 +518,16 @@ document.addEventListener('DOMContentLoaded', () => {
         selectClient?.addEventListener('change', () => { const selectedEmail = selectClient.value; remplirChampsClient(selectedEmail === 'new' ? null : tousLesClients.find(c => c.email === selectedEmail)); });
         champsClient.typeRemise?.addEventListener('change', majAffichageRemise);
         modale.querySelector('.btn-ajouter')?.addEventListener('click', () => { if(valeurCompteur) valeurCompteur.textContent = parseInt(valeurCompteur.textContent, 10) + 1; mettreAJourCreneauxDisponibles(); });
-        modale.querySelector('.btn-retirer')?.addEventListener('click', () => { if(valeurCompteur) { let arrets = parseInt(valeurCompteur.textContent, 10); if(arrets > 0) valeurCompteur.textContent = arrets - 1; mettreAJourCreneauxDisponibles(); } });
+        modale.querySelector('.btn-retirer')?.addEventListener('click', () => { if(valeurCompteur) { let arrets = parseInt(valeurCompteur.textContent, 10); if(arrets > 1) valeurCompteur.textContent = arrets - 1; mettreAJourCreneauxDisponibles(); } });
         champDateAjout?.addEventListener('change', mettreAJourCreneauxDisponibles);
         checkRetour?.addEventListener('change', mettreAJourCreneauxDisponibles);
         function mettreAJourCreneauxDisponibles() {
-            const arretsSupplementaires = parseInt(valeurCompteur?.textContent || '0', 10);
+            const totalStops = parseInt(valeurCompteur?.textContent || '1', 10);
             const retour = checkRetour?.checked || false;
             const date = champDateAjout?.value;
             const DUREE_BASE = 30; const DUREE_ARRET_SUP = 15;
-            const duree = DUREE_BASE + (arretsSupplementaires + (retour ? 1 : 0)) * DUREE_ARRET_SUP;
+            const nbSupp = Math.max(0, totalStops - 1);
+            const duree = DUREE_BASE + (nbSupp + (retour ? 1 : 0)) * DUREE_ARRET_SUP;
             if (!date) return;
             conteneurCreneaux?.classList.remove('hidden');
             if (grilleCreneaux) renderMessage(grilleCreneaux, 'Chargement...', 'i');

--- a/Client_JS.html
+++ b/Client_JS.html
@@ -248,15 +248,16 @@ document.addEventListener('DOMContentLoaded', () => {
         const resa = toutesLesReservationsClient.find(r => r.id === idReservation);
         if (!resa || !contenuModale) return;
 
-        const matchArrets = resa.details.match(/(\d+)\s*arrêt\(s\)\s*sup/);
-        const arretsActuels = matchArrets ? parseInt(matchArrets[1], 10) : 0;
+        const matchTotal = resa.details.match(/(\d+)\s*arrêt\(s\)\s*total\(s\)/);
+        const matchSup = resa.details.match(/(\d+)\s*arrêt\(s\)\s*sup/);
+        const arretsActuels = matchTotal ? parseInt(matchTotal[1], 10) : (matchSup ? parseInt(matchSup[1], 10) + 1 : 1);
 
         renderHTML(contenuModale, `
             <h3 id="modale-modification-titre">Modifier les arrêts</h3>
             <p><strong>Course :</strong> ${escapeHTML(new Date(resa.start).toLocaleString('fr-FR'))}</p>
             <div class="groupe-formulaire">
-                <label for="nouveaux-arrets">Nombre d'arrêts supplémentaires :</label>
-                <input type="number" id="nouveaux-arrets" class="champ-formulaire" value="${escapeHTML(String(arretsActuels))}" min="0">
+                <label for="nouveaux-arrets">Nombre d'arrêt(s) total(s) :</label>
+                <input type="number" id="nouveaux-arrets" class="champ-formulaire" value="${escapeHTML(String(arretsActuels))}" min="1">
             </div>
             <div class="modale-actions">
                 <button id="btn-valider-modif-arrets" class="btn btn-primaire btn--client">Valider</button>
@@ -329,9 +330,9 @@ document.addEventListener('DOMContentLoaded', () => {
     /**
      * Valide et envoie la modification du nombre d'arrêts.
      * @param {string} idReservation L'ID de la réservation.
-     * @param {number} nouveauxArrets Le nouveau nombre d'arrêts.
+     * @param {number} totalStops Le nouveau nombre d'arrêts totaux.
      */
-    function validerModificationArrets(idReservation, nouveauxArrets) {
+    function validerModificationArrets(idReservation, totalStops) {
         basculerIndicateurChargement(true);
         modale?.classList.add('hidden');
         google.script.run
@@ -344,7 +345,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             })
             .withFailureHandler(afficherErreur)
-            .mettreAJourDetailsReservation(idReservation, nouveauxArrets);
+            .mettreAJourDetailsReservation(idReservation, totalStops);
     }
 
     /**

--- a/Gestion.gs
+++ b/Gestion.gs
@@ -67,17 +67,19 @@ function obtenirReservationsClient(emailClient) {
         }
         
         const details = String(ligne[indices["Détails"]]);
-        const matchArrets = details.match(/(\d+)\s*arrêt\(s\)\s*sup/);
-        const arrets = matchArrets ? parseInt(matchArrets[1], 10) : 0;
+        const matchTotal = details.match(/(\d+)\s*arrêt\(s\)\s*total\(s\)/);
+        const matchSup = details.match(/(\d+)\s*arrêt\(s\)\s*sup/);
+        const totalStops = matchTotal ? parseInt(matchTotal[1], 10) : (matchSup ? parseInt(matchSup[1], 10) + 1 : 1);
         const retour = details.includes('retour: oui');
-        
+        const nbSupp = Math.max(0, totalStops - 1);
+
         if (!dateFin) {
-            const totalArretsCalcules = arrets + (retour ? 1 : 0);
+            const totalArretsCalcules = nbSupp + (retour ? 1 : 0);
             const dureeEstimee = DUREE_BASE + (totalArretsCalcules * DUREE_ARRET_SUP);
             dateFin = new Date(dateDebut.getTime() + dureeEstimee * 60000);
         }
-        
-        const totalArretsCalculesPourKm = arrets + (retour ? 1 : 0);
+
+        const totalArretsCalculesPourKm = nbSupp + (retour ? 1 : 0);
         const km = KM_BASE + (totalArretsCalculesPourKm * KM_ARRET_SUP);
 
         return {
@@ -235,10 +237,10 @@ function envoyerFactureClient(emailClient, numeroFacture) {
 /**
  * Met à jour les détails (nombre d'arrêts, prix, durée) d'une réservation existante.
  * @param {string} idReservation L'ID unique de la réservation à modifier.
- * @param {number} nouveauxArrets Le nouveau nombre d'arrêts supplémentaires.
+ * @param {number} totalStops Le nouveau nombre d'arrêt(s) total(s).
  * @returns {Object} Un résumé de l'opération.
  */
-function mettreAJourDetailsReservation(idReservation, nouveauxArrets) {
+function mettreAJourDetailsReservation(idReservation, totalStops) {
   const lock = LockService.getScriptLock();
   if (!lock.tryLock(30000)) return { success: false, error: "Le système est occupé, veuillez réessayer." };
 
@@ -279,15 +281,16 @@ function mettreAJourDetailsReservation(idReservation, nouveauxArrets) {
     const retourPharmacie = detailsAnciens.includes('retour: oui');
 
     const clientPourCalcul = obtenirInfosClientParEmail(emailClient);
-    const { prix: nouveauPrix, duree: nouvelleDuree } = calculerPrixEtDureeServeur(nouveauxArrets + 1, retourPharmacie, dateEvenement, heureEvenement, clientPourCalcul);
-    const nouveauxDetails = `Tournée de ${nouvelleDuree}min (${nouveauxArrets} arrêt(s) sup., retour: ${retourPharmacie ? 'oui' : 'non'})`;
+    const { prix: nouveauPrix, duree: nouvelleDuree, details: nouveauxDetails } = calculerPrixEtDureeServeur(totalStops, retourPharmacie, dateEvenement, heureEvenement, clientPourCalcul);
     
     // Si l'événement existe, on le met à jour
     if (ressourceEvenement) {
       const nouvelleDateFin = new Date(dateDebutOriginale.getTime() + nouvelleDuree * 60000);
       const ressourceMaj = {
         end: { dateTime: nouvelleDateFin.toISOString() },
-        description: ressourceEvenement.description.replace(/Total:.*€/, `Total: ${nouveauPrix.toFixed(2)} €`).replace(/Arrêts suppl:.*\n/, `Arrêts suppl: ${nouveauxArrets}, Retour: ${retourPharmacie ? 'Oui' : 'Non'}\n`)
+        description: ressourceEvenement.description
+          .replace(/Total:.*€/, `Total: ${nouveauPrix.toFixed(2)} €`)
+          .replace(/Arrêts (?:suppl|totaux):.*\n/, `Arrêts totaux: ${totalStops}, Retour: ${retourPharmacie ? 'Oui' : 'Non'}\n`)
       };
       Calendar.Events.patch(ressourceMaj, getSecret('ID_CALENDRIER'), idEvenement);
     }
@@ -295,8 +298,8 @@ function mettreAJourDetailsReservation(idReservation, nouveauxArrets) {
     // On met TOUJOURS à jour la feuille de calcul
     feuille.getRange(indexLigne + 1, indices.details + 1).setValue(nouveauxDetails);
     feuille.getRange(indexLigne + 1, indices.montant + 1).setValue(nouveauPrix);
-    
-    logActivity(idReservation, emailClient, `Modification: ${nouveauxArrets} arrêts supplémentaires.`, nouveauPrix, "Modification");
+
+    logActivity(idReservation, emailClient, `Modification: ${totalStops} arrêts totaux.`, nouveauPrix, "Modification");
     return { success: true };
 
   } catch (e) {

--- a/Pricing.gs
+++ b/Pricing.gs
@@ -1,0 +1,45 @@
+/**
+ * Fonctions utilitaires de tarification.
+ * Calcule le prix d'une course à partir du nombre total d'arrêts.
+ */
+
+function computeSupplementCost(nSupp) {
+  const arr = (typeof TARIFS !== 'undefined' && TARIFS.Normal && TARIFS.Normal.arrets)
+    ? TARIFS.Normal.arrets
+    : [];
+  const fallback = arr.length ? arr[arr.length - 1] : 0;
+  let sum = 0;
+  for (let i = 0; i < nSupp; i++) sum += (i < arr.length ? arr[i] : fallback);
+  return sum;
+}
+
+function computeCoursePrice(opts) {
+  opts = opts || {};
+  const totalStops = opts.totalStops === undefined ? 1 : opts.totalStops;
+  const retour = opts.retour === true;
+  const urgent = opts.urgent === true;
+  const samedi = opts.samedi === true;
+  const remise = opts.remise || 0;
+
+  const nbSupp = Math.max(0, (totalStops | 0) - 1);
+  const base = TARIFS.Normal.base;
+  const supplements = computeSupplementCost(nbSupp);
+  const retourFee = retour ? (computeSupplementCost(nbSupp + 1) - supplements) : 0;
+  const surcUrg = urgent ? (TARIFS.Urgent.base - base) : 0;
+  const surcSam = samedi ? (TARIFS.Samedi.base - base) : 0;
+
+  let total = base + supplements + retourFee + surcUrg + surcSam - remise;
+
+  return {
+    total: total,
+    nbSupp: nbSupp,
+    breakdown: {
+      base: base,
+      supplements: supplements,
+      retour: retourFee,
+      urgent: surcUrg,
+      samedi: surcSam,
+      remise: remise
+    }
+  };
+}

--- a/Pricing_JS.html
+++ b/Pricing_JS.html
@@ -1,0 +1,39 @@
+<script>
+/**
+ * Fonctions utilitaires de tarification pour le client.
+ */
+function computeSupplementCost(nSupp) {
+  const arr = (typeof configServeur !== 'undefined' && configServeur.TARIFS && configServeur.TARIFS.Normal && configServeur.TARIFS.Normal.arrets)
+    ? configServeur.TARIFS.Normal.arrets
+    : [];
+  const fallback = arr.length ? arr[arr.length - 1] : 0;
+  let sum = 0;
+  for (let i = 0; i < nSupp; i++) sum += (i < arr.length ? arr[i] : fallback);
+  return sum;
+}
+
+function computeCoursePrice(opts = {}) {
+  const {
+    totalStops = 1,
+    retour = false,
+    urgent = false,
+    samedi = false,
+    remise = 0
+  } = opts;
+
+  const nbSupp = Math.max(0, (totalStops | 0) - 1);
+  const base = configServeur.TARIFS.Normal.base;
+  const supplements = computeSupplementCost(nbSupp);
+  const retourFee = retour ? (computeSupplementCost(nbSupp + 1) - supplements) : 0;
+  const surcUrg = urgent ? (configServeur.TARIFS.Urgent.base - base) : 0;
+  const surcSam = samedi ? (configServeur.TARIFS.Samedi.base - base) : 0;
+
+  let total = base + supplements + retourFee + surcUrg + surcSam - remise;
+
+  return {
+    total,
+    nbSupp,
+    breakdown: { base, supplements, retour: retourFee, urgent: surcUrg, samedi: surcSam, remise }
+  };
+}
+</script>

--- a/Reservation_Interface.html
+++ b/Reservation_Interface.html
@@ -290,6 +290,7 @@
   <? } ?>
   <? if (THEME_V2_ENABLED) { ?>
   <?!= include('Render_JS'); ?>
+  <?!= include('Pricing_JS'); ?>
   <?!= include('Reservation_JS_UI'); ?>
   <?!= include('Reservation_JS_UI_Elements'); ?>
   <?!= include('Reservation_JS_Calendrier'); ?>

--- a/Reservation_JS_Panier.html
+++ b/Reservation_JS_Panier.html
@@ -29,7 +29,11 @@ function ajouterTourneeAuPanier() {
     returnToPharmacy: tourneeEnCours.returnToPharmacy,
     prix: parseFloat(creneauSelectionneBtn.dataset.prix),
     duree: tourneeEnCours.duree,
-    details: `Tournée de ${tourneeEnCours.duree}min (${Math.max(0, tourneeEnCours.totalStops - 1)} arrêt(s) sup., retour: ${tourneeEnCours.returnToPharmacy ? 'oui' : 'non'})`,
+    details: (() => {
+      const nbSupp = Math.max(0, tourneeEnCours.totalStops - 1);
+      const labelStops = `${tourneeEnCours.totalStops} arrêt(s) total(s)${nbSupp > 0 ? ` (dont ${nbSupp} supp.)` : ''}`;
+      return `Tournée de ${tourneeEnCours.duree}min (${labelStops}, retour: ${tourneeEnCours.returnToPharmacy ? 'oui' : 'non'})`;
+    })(),
     isRecurrent: estRecurrent // Nouvelle propriété
   };
 

--- a/Reservation_JS_Tournee.html
+++ b/Reservation_JS_Tournee.html
@@ -19,26 +19,18 @@ function calculerInfosTourneeClient(totalStops, returnToPharmacy, dateString, st
   const heureNormalisee = startTime.replace('h', ':');
   const dateCourse = new Date(`${dateString}T${heureNormalisee}`);
   const maintenant = new Date();
-  let typeCourse = 'Normal';
-  // Prioriser le samedi sur l'urgent
+  let urgent = false;
+  let samedi = false;
   if (dateCourse.getDay() === 6) {
-    typeCourse = 'Samedi';
+    samedi = true;
   } else if ((dateCourse.getTime() - maintenant.getTime()) / 60000 < configServeur.URGENT_THRESHOLD_MINUTES) {
-    typeCourse = 'Urgent';
+    urgent = true;
   }
-  const reglesTarifaires = configServeur.TARIFS[typeCourse] || configServeur.TARIFS['Normal'];
-  let prixFinal = reglesTarifaires.base;
-  for (let i = 0; i < arretsSupplementaires; i++) {
-    const prixArret = reglesTarifaires.arrets[i] || reglesTarifaires.arrets[reglesTarifaires.arrets.length - 1];
-    prixFinal += prixArret;
-  }
-  if (returnToPharmacy) {
-      const dernierIndexArretSup = arretsSupplementaires;
-      const prixRetour = reglesTarifaires.arrets[dernierIndexArretSup] || reglesTarifaires.arrets[reglesTarifaires.arrets.length - 1];
-      prixFinal += prixRetour;
-  }
-  const details = `Tournée de ${duree}min (${arretsSupplementaires} arrêt(s) sup., retour: ${returnToPharmacy ? 'oui' : 'non'})`;
-  return { prix: prixFinal, duree: duree, km: km, details: details, typeCourse: typeCourse };
+  const tarif = computeCoursePrice({ totalStops, retour: returnToPharmacy, urgent, samedi });
+  const typeCourse = samedi ? 'Samedi' : urgent ? 'Urgent' : 'Normal';
+  const labelStops = `${totalStops} arrêt(s) total(s)${tarif.nbSupp > 0 ? ` (dont ${tarif.nbSupp} supp.)` : ''}`;
+  const details = `Tournée de ${duree}min (${labelStops}, retour: ${returnToPharmacy ? 'oui' : 'non'})`;
+  return { prix: tarif.total, duree: duree, km: km, details: details, typeCourse: typeCourse };
 }
 
 /**
@@ -306,6 +298,8 @@ function ajouterTourneeAuPanier(isRecurrentItem = false, recurrenceData = null) 
     startTime = creneauSelectionneBtn.dataset.creneau;
     prix = parseFloat(creneauSelectionneBtn.dataset.prix);
   }
+  const nbSupp = Math.max(0, tourneeEnCours.totalStops - 1);
+  const labelStops = `${tourneeEnCours.totalStops} arrêt(s) total(s)${nbSupp > 0 ? ` (dont ${nbSupp} supp.)` : ''}`;
   const nouvelleTournee = {
     id: 'tournee-' + Date.now() + Math.random(),
     date: date,
@@ -314,7 +308,7 @@ function ajouterTourneeAuPanier(isRecurrentItem = false, recurrenceData = null) 
     returnToPharmacy: tourneeEnCours.returnToPharmacy,
     prix: prix,
     duree: tourneeEnCours.duree,
-    details: `Tournée de ${tourneeEnCours.duree}min (${Math.max(0, tourneeEnCours.totalStops - 1)} arrêt(s) sup., retour: ${tourneeEnCours.returnToPharmacy ? 'oui' : 'non'})`,
+    details: `Tournée de ${tourneeEnCours.duree}min (${labelStops}, retour: ${tourneeEnCours.returnToPharmacy ? 'oui' : 'non'})`,
     isRecurrent: isRecurrentItem
   };
   window.etat.panier.push(nouvelleTournee);


### PR DESCRIPTION
## Summary
- factorise computeCoursePrice/computeSupplementCost for server and client
- bascule UI/serveur vers le nombre d'arrêt(s) total(s)
- met à jour la mise à jour de réservation et les libellés

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb2ad4a8288326ad50e60d74283904