### PR TITLE
feat: add billing modal stub [flag:BILLING_MODAL_ENABLED]

### DIFF
--- a/Configuration.gs
+++ b/Configuration.gs
@@ -124,6 +124,9 @@ const RESERVATION_UI_V2_ENABLED = true;
 /** @const {boolean} Active la facturation directe au résident. */
 const RESIDENT_BILLING_ENABLED = true;
 
+/** @const {boolean} Active la modale de coordonnées de facturation. */
+const BILLING_MODAL_ENABLED = false;
+
 // --- Drapeaux de Débogage et de Test ---
 /** @const {boolean} Affiche le sous-menu Debug et l'interface associée. */
 const DEBUG_MENU_ENABLED = true;
@@ -166,6 +169,7 @@ const FLAGS = Object.freeze({
   calendarPurgeEnabled: CALENDAR_PURGE_ENABLED,
   reservationUiV2Enabled: RESERVATION_UI_V2_ENABLED,
   residentBillingEnabled: RESIDENT_BILLING_ENABLED,
+  billingModalEnabled: BILLING_MODAL_ENABLED,
   debugMenuEnabled: DEBUG_MENU_ENABLED,
   demoReservationEnabled: DEMO_RESERVATION_ENABLED,
   billingV2Dryrun: BILLING_V2_DRYRUN,
@@ -254,6 +258,7 @@ const CONFIG = Object.freeze({
   SEMAINIER_ENABLED,
   SHEET_RESERVATIONS,
   BILLING,
+  BILLING_MODAL_ENABLED,
   RESIDENT_BILLING_ENABLED,
   BILLING_V2_DRYRUN
 });

--- a/FacturationResident.gs
+++ b/FacturationResident.gs
@@ -3,6 +3,37 @@
  * Génère les lignes de facture et envoie un PDF par e-mail.
  */
 
+/**
+ * Renvoie les coordonnées de facturation par défaut selon le type.
+ * @param {string} orderId
+ * @param {string} billTo
+ * @param {Object} ctx
+ * @return {Object}
+ */
+function doGetBillingDefaults(orderId, billTo, ctx) {
+  return {
+    success: true,
+    defaults: {
+      nom: '',
+      adresse: '',
+      email: '',
+      telephone: '',
+      siret: '',
+      tva: ''
+    }
+  };
+}
+
+/**
+ * Persiste les coordonnées de facturation pour une commande.
+ * @param {Object} payload
+ * @return {Object}
+ */
+function doSaveBillingForOrder(payload) {
+  // TODO: écrire dans la feuille "Réservations" ou la table "Facturation".
+  return { success: true };
+}
+
 function bandIndexFromKm(km, bands) {
   for (var i = 0; i < bands.length; i++) {
     if (km <= bands[i]) {

--- a/Reservation_Interface.html
+++ b/Reservation_Interface.html
@@ -284,6 +284,46 @@
       </div>
   </div>
 
+  <!-- MODALE 5: Coordonnées de facturation -->
+  <div id="modale-billing" class="modale-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="billing-titre">
+      <div class="modale-contenu">
+          <button id="btn-fermer-billing" class="btn-fermer" aria-label="Fermer">&times;</button>
+          <h3 id="billing-titre">Coordonnées de facturation</h3>
+          <form id="formulaire-billing">
+              <div class="groupe-formulaire">
+                  <label for="billing-nom">Nom / Raison sociale</label>
+                  <input type="text" id="billing-nom" name="billingNom" required>
+              </div>
+              <div class="groupe-formulaire">
+                  <label for="billing-adresse">Adresse</label>
+                  <textarea id="billing-adresse" name="billingAdresse" rows="2"></textarea>
+              </div>
+              <div class="groupe-formulaire">
+                  <label for="billing-email">Email</label>
+                  <input type="email" id="billing-email" name="billingEmail">
+              </div>
+              <div class="groupe-formulaire">
+                  <label for="billing-telephone">Téléphone</label>
+                  <input type="tel" id="billing-telephone" name="billingTelephone">
+              </div>
+              <div class="groupe-formulaire">
+                  <label for="billing-siret">SIRET</label>
+                  <input type="text" id="billing-siret" name="billingSiret">
+              </div>
+              <div class="groupe-formulaire">
+                  <label for="billing-tva">TVA intracom</label>
+                  <input type="text" id="billing-tva" name="billingTva">
+              </div>
+              <div class="modale-pied-de-page">
+                  <button type="button" id="btn-billing-switch" class="btn btn-secondaire btn-sm hidden">Saisir nouvelles coordonnées</button>
+                  <span style="flex:1"></span>
+                  <button type="button" id="btn-billing-annuler" class="btn btn-secondaire">Annuler</button>
+                  <button type="submit" class="btn btn-primaire">Enregistrer</button>
+              </div>
+          </form>
+      </div>
+  </div>
+
   <div id="conteneur-notifications" role="alert" aria-live="assertive"></div>
   <? if (THEME_SELECTION_ENABLED) { ?>
     <?!= include('Script_ThemeSelector'); ?>

--- a/Reservation_JS_Principal.html
+++ b/Reservation_JS_Principal.html
@@ -26,6 +26,7 @@ function initializeFlags(flags = {}) {
     calendarPurgeEnabled: false,
     reservationUiV2Enabled: false,
     residentBillingEnabled: false,
+    billingModalEnabled: false,
     debugMenuEnabled: false,
     demoReservationEnabled: false,
     billingV2Dryrun: false,
@@ -181,6 +182,116 @@ function envoyerDevis(email) {
 }
 
 /**
+ * Ouvre la modale de coordonnées de facturation et gère la saisie.
+ * @param {Object} opts
+ */
+function openBillingModal(opts = {}) {
+  const modal = document.getElementById('modale-billing');
+  if (!modal) return;
+  const form = document.getElementById('formulaire-billing');
+  const btnAnnuler = document.getElementById('btn-billing-annuler');
+  const btnFermer = document.getElementById('btn-fermer-billing');
+  const btnSwitch = document.getElementById('btn-billing-switch');
+  let lastFocus = document.activeElement;
+
+  function remplir(data) {
+    form.billingNom.value = data.nom || '';
+    form.billingAdresse.value = data.adresse || '';
+    form.billingEmail.value = data.email || '';
+    form.billingTelephone.value = data.telephone || '';
+    form.billingSiret.value = data.siret || '';
+    form.billingTva.value = data.tva || '';
+  }
+
+  if (opts.defaults) {
+    remplir(opts.defaults);
+  } else {
+    google.script.run.withSuccessHandler(r => {
+      if (r && r.defaults) remplir(r.defaults);
+    }).doGetBillingDefaults(opts.orderId, opts.billTo, opts.ctx);
+  }
+
+  if (opts.mode === 'existant') {
+    Array.from(form.elements).forEach(el => {
+      if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') {
+        el.readOnly = true;
+      }
+    });
+    btnSwitch.classList.remove('hidden');
+  } else {
+    btnSwitch.classList.add('hidden');
+  }
+
+  function activerEdition() {
+    Array.from(form.elements).forEach(el => {
+      if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') {
+        el.readOnly = false;
+      }
+    });
+    btnSwitch.classList.add('hidden');
+  }
+  btnSwitch.addEventListener('click', activerEdition, { once: true });
+
+  function fermer() {
+    modal.classList.add('hidden');
+    form.reset();
+    btnSwitch.classList.add('hidden');
+    modal.removeEventListener('keydown', trap);    
+    if (lastFocus) lastFocus.focus();
+  }
+
+  btnAnnuler.addEventListener('click', fermer, { once: true });
+  btnFermer.addEventListener('click', fermer, { once: true });
+
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    const payload = {
+      orderId: opts.orderId,
+      billTo: opts.billTo,
+      nom: form.billingNom.value.trim(),
+      adresse: form.billingAdresse.value.trim(),
+      email: form.billingEmail.value.trim(),
+      telephone: form.billingTelephone.value.trim(),
+      siret: form.billingSiret.value.trim(),
+      tva: form.billingTva.value.trim()
+    };
+    google.script.run.withSuccessHandler(res => {
+      if (res && res.success) {
+        fermer();
+        window.dispatchEvent(new CustomEvent('billing:saved', { detail: res }));
+      } else {
+        afficherNotification('Erreur lors de l\'enregistrement.', 'erreur');
+      }
+    }).doSaveBillingForOrder(payload);
+  }, { once: true });
+
+  function trap(ev) {
+    if (ev.key === 'Escape') {
+      fermer();
+    }
+    if (ev.key === 'Tab') {
+      const focusables = modal.querySelectorAll('button, [href], input, textarea, select, [tabindex]:not([tabindex="-1"])');
+      const list = Array.prototype.filter.call(focusables, el => !el.disabled && el.offsetParent !== null);
+      if (list.length === 0) return;
+      const first = list[0];
+      const last = list[list.length - 1];
+      if (ev.shiftKey && document.activeElement === first) {
+        ev.preventDefault();
+        last.focus();
+      } else if (!ev.shiftKey && document.activeElement === last) {
+        ev.preventDefault();
+        first.focus();
+      }
+    }
+  }
+  modal.addEventListener('keydown', trap);
+
+  modal.classList.remove('hidden');
+  const firstField = modal.querySelector('input, textarea, select, button');
+  if (firstField) firstField.focus();
+}
+
+/**
 
  * Gère la soumission du formulaire de réservation final.
  * @param {SubmitEvent} e
@@ -195,8 +306,6 @@ function gererSoumissionReservation(e) {
     return;
   }
 
-  basculerIndicateurChargement(true);
-
   const donneesReservation = {
     client: {
       email: ui.champEmailClient.value.trim(),
@@ -208,27 +317,41 @@ function gererSoumissionReservation(e) {
     items: panier
   };
 
-  google.script.run
-    .withSuccessHandler(reponse => {
-      basculerIndicateurChargement(false);
-      if (reponse.success) {
-        afficherNotification("Réservation confirmée ! Un email vous a été envoyé.", 'succes');
-        window.etat.panier = [];
-        sauvegarderPanierDansLocalStorage();
-        afficherPanier();
-        ui.conteneurFinalisation.classList.add('hidden');
-        localStorage.setItem(CLE_LOCALSTORAGE_CLIENT, JSON.stringify(donneesReservation.client));
-      } else {
-        afficherErreur(reponse.summary || "Une erreur est survenue lors de la réservation.");
-        if (reponse.failedItemIds && reponse.failedItemIds.length > 0) {
-          window.etat.panier = window.etat.panier.filter(item => !reponse.failedItemIds.includes(item.id));
+  function envoyer() {
+    basculerIndicateurChargement(true);
+    google.script.run
+      .withSuccessHandler(reponse => {
+        basculerIndicateurChargement(false);
+        if (reponse.success) {
+          afficherNotification("Réservation confirmée ! Un email vous a été envoyé.", 'succes');
+          window.etat.panier = [];
           sauvegarderPanierDansLocalStorage();
           afficherPanier();
+          ui.conteneurFinalisation.classList.add('hidden');
+          localStorage.setItem(CLE_LOCALSTORAGE_CLIENT, JSON.stringify(donneesReservation.client));
+        } else {
+          afficherErreur(reponse.summary || "Une erreur est survenue lors de la réservation.");
+          if (reponse.failedItemIds && reponse.failedItemIds.length > 0) {
+            window.etat.panier = window.etat.panier.filter(item => !reponse.failedItemIds.includes(item.id));
+            sauvegarderPanierDansLocalStorage();
+            afficherPanier();
+          }
         }
-      }
-    })
-    .withFailureHandler(afficherErreur)
-    .reserverPanier(donneesReservation);
+      })
+      .withFailureHandler(afficherErreur)
+      .reserverPanier(donneesReservation);
+  }
+
+  if (window.etat.flags.billingModalEnabled) {
+    openBillingModal({ orderId: Date.now().toString(), billTo: 'resident', mode: 'existant' });
+    const handler = () => {
+      window.removeEventListener('billing:saved', handler);
+      envoyer();
+    };
+    window.addEventListener('billing:saved', handler);
+  } else {
+    envoyer();
+  }
 }
 
 /**
@@ -289,6 +412,10 @@ function configurerEcouteursEvenements() {
   ui.formulaireReservation?.addEventListener('submit', gererSoumissionReservation);
   ui.btnAnnulerReservation?.addEventListener('click', () => ui.conteneurFinalisation.classList.add('hidden'));
   ui.listePanier?.addEventListener('click', gererActionsPanier);
+
+  window.addEventListener('billing:saved', () => {
+    afficherNotification('Coordonnées de facturation enregistrées.', 'succes');
+  });
 
   // Écouteurs pour la modale de demande d'email pour le devis
   const modaleEmailDevis = document.getElementById('modale-email-devis');


### PR DESCRIPTION
## Summary
- add BILLING_MODAL_ENABLED flag and expose in configuration
- integrate billing coordinates modal with client submission flow
- stub server handlers for fetching and saving billing data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbd887c1688326a9981ae916c831cf