### PR TITLE
feat: add theme-unique UI

### DIFF
--- a/ui/a11y.js
+++ b/ui/a11y.js
@@ -1,0 +1,66 @@
+/* ===========================================================
+   A11y helpers — focus trap pour <dialog>, gestion ESC
+   =========================================================== */
+function focusableSelectors(){
+  return [
+    'a[href]','area[href]','input:not([disabled])','select:not([disabled])',
+    'textarea:not([disabled])','button:not([disabled])','iframe','object','embed',
+    '[contenteditable]','[tabindex]:not([tabindex="-1"])'
+  ].join(',');
+}
+
+function trapFocus(container){
+  const focusables = Array.from(container.querySelectorAll(focusableSelectors()))
+    .filter(el=>el.offsetParent !== null || container.open); // garder éléments visibles
+  const first = focusables[0];
+  const last = focusables[focusables.length-1];
+
+  function onKey(e){
+    if(e.key === "Tab"){
+      if(e.shiftKey && document.activeElement === first){ last.focus(); e.preventDefault(); }
+      else if(!e.shiftKey && document.activeElement === last){ first.focus(); e.preventDefault(); }
+    }else if(e.key === "Escape"){
+      // si c'est un <dialog>, on peut le fermer
+      const isDialog = container.nodeName.toLowerCase()==="dialog";
+      if(isDialog) closeDialog(container);
+    }
+  }
+
+  container.__focusTrapHandler = onKey; // store
+  container.addEventListener("keydown", onKey);
+  first?.focus();
+}
+
+function releaseTrap(container){
+  if(container.__focusTrapHandler){
+    container.removeEventListener("keydown", container.__focusTrapHandler);
+    delete container.__focusTrapHandler;
+  }
+}
+
+// Ouvre un <dialog> accessible (ou un div modal)
+function openDialog(el){
+  if(el.nodeName.toLowerCase()==="dialog" && typeof el.showModal === "function"){
+    el.showModal();
+  }else{
+    el.hidden = false; el.setAttribute("aria-modal","true");
+  }
+  trapFocus(el);
+}
+
+// Ferme le <dialog>
+function closeDialog(el){
+  releaseTrap(el);
+  if(el.nodeName.toLowerCase()==="dialog" && typeof el.close === "function"){
+    el.close();
+  }else{
+    el.hidden = true; el.removeAttribute("aria-modal");
+  }
+  // focus de confort : ramener sur l’élément déclencheur si possible
+  const opener = document.querySelector('[data-open="'+el.id+'"]');
+  opener?.focus();
+}
+
+// Expose global (facile à utiliser dans app.js)
+window.openDialog = openDialog;
+window.closeDialog = closeDialog;

--- a/ui/app.js
+++ b/ui/app.js
@@ -1,0 +1,325 @@
+/* ===========================================================
+   ELS Front — thème unique / calendrier continu 15 min
+   Aucune dépendance externe. Compatible Apps Script WebApp.
+   =========================================================== */
+
+// ----- Config front (modifiable sans rebuild) -----
+const UI_CONFIG = {
+  STEP_MIN: 15,
+  START_TIME: "07:00",
+  END_TIME: "21:00",
+  WEEK_START: 1, // 1 = Lundi
+};
+
+// TARIFS par défaut (peuvent être écrasés par le serveur)
+window.TARIFS = window.TARIFS || {
+  baseCourse: 15,               // 1 retrait + 1 PDL, 9km, 30min
+  baseKm: 9,
+  baseMin: 30,
+  surcUrgence: 20,              // exemples visuels
+  surcSamedi: 25,
+  PDL_PRIX: [5,4,3,4,5],
+  PDL_PRIX_FALLBACK: 5
+};
+
+// ----- Helpers date/heure -----
+function toMinutes(hhmm){ const [h,m]=hhmm.split(":").map(Number); return h*60+m; }
+function pad2(n){ return String(n).padStart(2,"0"); }
+function minutesRange(start,end,step){
+  const out=[]; for(let t=toMinutes(start); t<=toMinutes(end); t+=step){
+    out.push(pad2(Math.floor(t/60))+":"+pad2(t%60));
+  } return out;
+}
+function startOfWeek(date, weekStart=1){
+  const d = new Date(date);
+  const day = (d.getDay()+6)%7; // 0 (Mon) .. 6 (Sun)
+  const diff = day - (weekStart-1);
+  d.setDate(d.getDate() - diff);
+  d.setHours(0,0,0,0);
+  return d;
+}
+function addDays(date, days){ const d=new Date(date); d.setDate(d.getDate()+days); return d; }
+function fmtDate(d){ return `${pad2(d.getDate())}/${pad2(d.getMonth()+1)}`; }
+function isoDate(d){ return d.toISOString().slice(0,10); }
+
+// ----- État global -----
+let baseDate = new Date(); // ancrage semaine courante
+let times = [];
+let selected = []; // [{dateISO,time}]
+let busyMap = new Map(); // key = dateISO → Set("HH:MM")
+let proxyInfo = null;
+
+// ----- Toast -----
+function showToast(msg, timeout=2500){
+  const el = document.getElementById("toast");
+  el.textContent = msg;
+  el.hidden = false;
+  setTimeout(()=>{ el.hidden=true; el.textContent=""; }, timeout);
+}
+
+// ----- Rendu semaine (barre titres) -----
+function renderWeekbar(weekStartDate){
+  const weekbar = document.getElementById("weekbar");
+  for(let i=0;i<7;i++){
+    const cell = weekbar.querySelector(`.day[data-day="${i}"]`);
+    const d = addDays(weekStartDate, i);
+    cell.textContent = ["Lun","Mar","Mer","Jeu","Ven","Sam","Dim"][i] + " " + fmtDate(d);
+    cell.setAttribute("data-date", isoDate(d));
+  }
+}
+
+// ----- Rendu grille -----
+function renderGrid(weekStartDate){
+  const grid = document.getElementById("cal-grid");
+  grid.innerHTML = "";
+
+  // 1) colonne des heures
+  const timeCol = document.createElement("div");
+  timeCol.className = "timecol";
+  timeCol.innerHTML = times.map(t=>`<div class="slot" aria-hidden="true">${t}</div>`).join("");
+  grid.appendChild(timeCol);
+
+  // 2) 7 colonnes jours
+  for(let dayIndex=0; dayIndex<7; dayIndex++){
+    const col = document.createElement("div");
+    const date = addDays(weekStartDate, dayIndex);
+    const dateISO = isoDate(date);
+    const busySet = busyMap.get(dateISO) || new Set();
+
+    times.forEach(t=>{
+      const cell = document.createElement("div");
+      cell.className = "slot";
+      if(busySet.has(t)) cell.setAttribute("data-state","busy");
+
+      const btn = document.createElement("button");
+      btn.type="button";
+      btn.setAttribute("aria-label", `Réserver ${t}`);
+      btn.textContent = t;
+
+      const isSel = selected.some(s=>s.dateISO===dateISO && s.time===t);
+      if(isSel) cell.setAttribute("data-selected","true");
+
+      btn.addEventListener("click", ()=>{
+        onSlotClick({ dateISO, dayIndex, time: t, busy: busySet.has(t) });
+      });
+
+      cell.appendChild(btn);
+      col.appendChild(cell);
+    });
+
+    grid.appendChild(col);
+  }
+}
+
+// ----- Sélection de créneau -----
+function onSlotClick({dateISO, dayIndex, time, busy}){
+  if(busy){ showToast("Ce créneau est déjà pris."); return; }
+
+  const idx = selected.findIndex(s=>s.dateISO===dateISO && s.time===time);
+  if(idx>=0){
+    selected.splice(idx,1); // toggle off
+  }else{
+    selected.push({dateISO, time});
+  }
+  renderCart();
+  // mise à jour visuelle rapide sans tout rerendre
+  const grid = document.getElementById("cal-grid");
+  const dayCol = grid.children[dayIndex+1]; // +1 à cause de la timecol
+  const timeIdx = times.indexOf(time);
+  const cell = dayCol.children[timeIdx];
+  const isSelected = cell.getAttribute("data-selected")==="true";
+  cell.setAttribute("data-selected", isSelected ? "false" : "true");
+  if(isSelected) cell.removeAttribute("data-selected");
+}
+
+// ----- Panier -----
+function renderCart(){
+  const list = document.getElementById("cart-list");
+  const empty = document.getElementById("cart-empty");
+  const totalEl = document.getElementById("cart-total");
+
+  list.innerHTML = "";
+  if(selected.length===0){
+    empty.hidden = false;
+    totalEl.textContent = "0,00 €";
+    return;
+  }
+  empty.hidden = true;
+
+  const days = ["Lun","Mar","Mer","Jeu","Ven","Sam","Dim"];
+  const weekStart = startOfWeek(baseDate, UI_CONFIG.WEEK_START);
+  selected
+    .slice()
+    .sort((a,b)=> (a.dateISO+a.time).localeCompare(b.dateISO+b.time))
+    .forEach((it, i)=>{
+      const d = new Date(it.dateISO+"T00:00:00");
+      const dayIndex = Math.round((d - weekStart)/(24*3600*1000));
+      const li = document.createElement("li");
+      li.className = "cart-item";
+      li.innerHTML = `
+        <span>${days[dayIndex] || it.dateISO} • ${it.time}</span>
+        <button class="btn ghost" aria-label="Retirer" type="button">Retirer</button>
+      `;
+      li.querySelector("button").addEventListener("click",()=>{
+        selected.splice(i,1); renderCart();
+        // aussi nettoyer marquage visuel si visible
+        const grid = document.getElementById("cal-grid");
+        const dayCol = grid.children[dayIndex+1];
+        const idx = times.indexOf(it.time);
+        const cell = dayCol?.children?.[idx];
+        if(cell) cell.removeAttribute("data-selected");
+      });
+      list.appendChild(li);
+    });
+
+  // Calcul total (estimation côté front)
+  const total = computePrice(selected);
+  totalEl.textContent = total.toFixed(2).replace(".", ",") + " €";
+}
+
+// ----- Calcul de prix (simple — remplaçable par le serveur) -----
+function computePrice(items){
+  if(items.length===0) return 0;
+  const T = window.TARIFS || {};
+  const base = Number(T.baseCourse ?? 15);
+  // Arrêts sup. = nombre de créneaux - 1 (le premier inclus)
+  const extra = Math.max(0, items.length - 1);
+  let extraSum = 0;
+  for(let i=0;i<extra;i++){
+    extraSum += (T.PDL_PRIX?.[i] ?? T.PDL_PRIX_FALLBACK ?? 5);
+  }
+  // Exemple : si un créneau tombe un samedi, appliquer surcSamedi (au moins une fois)
+  const hasSaturday = items.some(it => new Date(it.dateISO).getDay()===6);
+  const samedi = hasSaturday ? Number(T.surcSamedi ?? 0) : 0;
+
+  return base + extraSum + samedi;
+}
+
+// ----- Chargement des créneaux occupés (peut appeler Apps Script) -----
+function loadBusyForWeek(weekStartDate){
+  busyMap.clear();
+
+  // Si Apps Script est dispo, on appelle le backend
+  if(window.google && google.script && google.script.run){
+    const iso = isoDate(weekStartDate);
+    google.script.run
+      .withSuccessHandler((data)=>{
+        // data attendu: [{dateISO:"2025-09-06", times:["07:00","07:15",...]}]
+        (data||[]).forEach(d=>{
+          busyMap.set(d.dateISO, new Set(d.times||[]));
+        });
+        renderGrid(weekStartDate);
+      })
+      .withFailureHandler(()=>{ renderGrid(weekStartDate); })
+      .getBusySlotsForWeek(iso); // à implémenter côté serveur
+    return;
+  }
+
+  // Fallback démo côté client (simule quelques slots pris)
+  for(let i=0;i<7;i++){
+    const dateISO = isoDate(addDays(weekStartDate,i));
+    const set = new Set();
+    // Exemple: bloquer 10:00 et 10:15 les jours pairs
+    if(i%2===0){ set.add("10:00"); set.add("10:15"); }
+    busyMap.set(dateISO,set);
+  }
+  renderGrid(weekStartDate);
+}
+
+// ----- Navigation semaine -----
+function renderWeek(){
+  const weekStart = startOfWeek(baseDate, UI_CONFIG.WEEK_START);
+  renderWeekbar(weekStart);
+  times = minutesRange(UI_CONFIG.START_TIME, UI_CONFIG.END_TIME, UI_CONFIG.STEP_MIN);
+  loadBusyForWeek(weekStart);
+}
+
+function nextWeek(){ baseDate = addDays(baseDate, 7); renderWeek(); }
+function prevWeek(){ baseDate = addDays(baseDate,-7); renderWeek(); }
+
+// ----- Modale déclenchement par tiers -----
+function initProxyDialog(){
+  const dlg = document.getElementById("dlg-proxy");
+  const btnOpeners = document.querySelectorAll('[data-open="dlg-proxy"]');
+  const btnClosers = dlg.querySelectorAll("[data-close]");
+  const chkBilling = document.getElementById("chk-billing");
+  const billingFields = document.getElementById("billing-fields");
+  const form = document.getElementById("frm-proxy");
+
+  btnOpeners.forEach(b=>b.addEventListener("click",()=>openDialog(dlg)));
+  btnClosers.forEach(b=>b.addEventListener("click",()=>closeDialog(dlg)));
+  chkBilling.addEventListener("change",()=>{ billingFields.hidden = !chkBilling.checked; });
+
+  form.addEventListener("submit",(ev)=>{
+    ev.preventDefault();
+    const fd = new FormData(form);
+    proxyInfo = {
+      residentName: fd.get("residentName") || "",
+      org: fd.get("org") || "",
+      phone: fd.get("phone") || "",
+      email: fd.get("email") || "",
+      billing: chkBilling.checked ? {
+        name: fd.get("billingName") || "",
+        email: fd.get("billingEmail") || "",
+        ref: fd.get("billingRef") || ""
+      } : null
+    };
+    closeDialog(dlg);
+    showToast("Coordonnées enregistrées.");
+  });
+}
+
+// ----- Actions panier -----
+function initCartActions(){
+  document.getElementById("btn-vider").addEventListener("click",()=>{
+    selected.length = 0; renderCart(); renderWeek();
+  });
+
+  document.getElementById("btn-valider").addEventListener("click",()=>{
+    if(selected.length===0){ showToast("Ajoutez au moins un créneau."); return; }
+
+    const payload = { slots: selected.slice(), proxyInfo };
+    // Appel serveur si dispo
+    if(window.google && google.script && google.script.run){
+      document.getElementById("btn-valider").disabled = true;
+      google.script.run
+        .withSuccessHandler((res)=>{
+          document.getElementById("btn-valider").disabled = false;
+          // res: {ok:true, conflicts:[{dateISO,time}]}
+          if(res?.conflicts?.length){
+            showToast("Certains créneaux viennent d’être pris.");
+            res.conflicts.forEach(c=>{
+              const set = busyMap.get(c.dateISO) || new Set();
+              set.add(c.time); busyMap.set(c.dateISO,set);
+              // retirer du panier si présent
+              const idx = selected.findIndex(s=>s.dateISO===c.dateISO && s.time===c.time);
+              if(idx>=0) selected.splice(idx,1);
+            });
+            renderCart(); renderWeek();
+          }else{
+            showToast("Réservation enregistrée.");
+            selected.length = 0; renderCart(); renderWeek();
+          }
+        })
+        .withFailureHandler((err)=>{
+          document.getElementById("btn-valider").disabled = false;
+          console.error(err); showToast("Erreur réseau. Réessayez.");
+        })
+        .createBooking(payload); // à implémenter côté serveur
+      return;
+    }
+
+    // Fallback local
+    showToast("Réservation (démo) enregistrée.");
+    selected.length=0; renderCart(); renderWeek();
+  });
+}
+
+// ----- Bootstrap -----
+document.addEventListener("DOMContentLoaded", ()=>{
+  document.getElementById("prev-week").addEventListener("click", prevWeek);
+  document.getElementById("next-week").addEventListener("click", nextWeek);
+  initProxyDialog();
+  initCartActions();
+  renderWeek();
+});

--- a/ui/assets/logo.svg
+++ b/ui/assets/logo.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" role="img" aria-label="Logo ELS">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="50%" x2="100%" y2="50%">
+      <stop offset="0%" stop-color="#8e44ad"/>
+      <stop offset="100%" stop-color="#3498db"/>
+    </linearGradient>
+  </defs>
+  <circle cx="20" cy="20" r="18" fill="url(#g)"/>
+  <text x="20" y="24" text-anchor="middle" font-family="Montserrat, sans-serif" font-size="14" font-weight="700" fill="#fff">ELS</text>
+</svg>

--- a/ui/calendar.css
+++ b/ui/calendar.css
@@ -1,0 +1,46 @@
+/* =========================
+   Calendar grid (15-min continuous)
+   ========================= */
+.calendar h2{margin:.25rem 0}
+.calendar__toolbar{
+  display:flex;align-items:center;justify-content:space-between;gap:.5rem;margin-bottom:.25rem
+}
+.weekbar{
+  display:grid;grid-template-columns:60px repeat(7,1fr);gap:.5rem;align-items:end
+}
+.weekbar .day{
+  display:flex;justify-content:center;align-items:flex-end;font-weight:700;min-height:32px
+}
+
+/* Grid with first column = times */
+.grid{
+  display:grid;grid-template-columns:60px repeat(7,1fr);gap:.5rem;margin-top:.5rem
+}
+.timecol{color:var(--els-muted);font-size:.8rem}
+.timecol .slot{border:none;background:transparent;padding:.25rem 0;min-height:36px}
+
+.slot{
+  position:relative;padding:.25rem;border-radius:12px;border:1px dashed #e5e7eb;min-height:36px;background:#fff;display:flex
+}
+.slot button{
+  all:unset;display:block;width:100%;height:100%;cursor:pointer;border-radius:inherit;padding:.25rem .4rem;text-align:center
+}
+.slot button:focus-visible{box-shadow:var(--ring)}
+.slot[data-state="busy"]{background:repeating-linear-gradient(135deg,#f3f4f6,#f3f4f6 8px,#eef2ff 8px,#eef2ff 16px)}
+.slot[data-selected="true"]{outline:2px solid var(--els-accent);outline-offset:1px}
+
+/* Subtle day gradients (lun → dim) */
+.grid > :nth-child(7n+2) .slot{background:linear-gradient(180deg,#f9f5ff 0%,#eef2ff 100%)}
+.grid > :nth-child(7n+3) .slot{background:linear-gradient(180deg,#f7faff 0%,#eff6ff 100%)}
+.grid > :nth-child(7n+4) .slot{background:linear-gradient(180deg,#f8fbff 0%,#edf7ff 100%)}
+.grid > :nth-child(7n+5) .slot{background:linear-gradient(180deg,#f9fbff 0%,#edf6ff 100%)}
+.grid > :nth-child(7n+6) .slot{background:linear-gradient(180deg,#fbfdff 0%,#eef7ff 100%)}
+.grid > :nth-child(7n+7) .slot{background:linear-gradient(180deg,#fbf9ff 0%,#f0f4ff 100%)}
+.grid > :nth-child(7n+8) .slot{background:linear-gradient(180deg,#fdf9ff 0%,#f2f4ff 100%)}
+
+/* Mobile tweaks */
+@media (max-width: 720px){
+  .weekbar{grid-template-columns:44px repeat(7,1fr)}
+  .grid{grid-template-columns:44px repeat(7,1fr)}
+  .timecol{font-size:.72rem}
+}

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ELS • Réservations</title>
+
+  <!-- Police -->
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap" rel="stylesheet">
+
+  <!-- Styles -->
+  <link rel="stylesheet" href="./theme.css">
+  <link rel="stylesheet" href="./calendar.css">
+</head>
+<body>
+  <!-- Header -->
+  <header class="card header" role="banner" aria-label="Système de réservation ELS">
+    <div class="header__left">
+      <img src="./assets/logo.svg" alt="Logo ELS" width="40" height="40" />
+      <strong class="app-title">ELS • Système de réservation</strong>
+    </div>
+    <nav class="header__right" aria-label="Liens principaux">
+      <button class="btn ghost" id="btn-espace-client" type="button">Mon Espace Client</button>
+    </nav>
+  </header>
+
+  <!-- Bandeau info (optionnel) -->
+  <div class="notice" role="status">
+    <strong>Info :</strong> Créneaux toutes <b>15 min</b>, journée continue <b>07:00 → 21:00</b>. 
+  </div>
+
+  <!-- Grille 2 colonnes -->
+  <main class="layout">
+    <section aria-labelledby="tit-tarifs" class="card">
+      <h2 id="tit-tarifs">Tarifs et options</h2>
+      <div class="pricing">
+        <div class="pricing__col">
+          <h3>Course de base</h3>
+          <ul>
+            <li>15 € TTC</li>
+            <li>9 km inclus</li>
+            <li>30 min inclus</li>
+          </ul>
+          <button class="btn" id="btn-reserver" type="button">Réserver</button>
+        </div>
+        <div class="pricing__col">
+          <h3>Arrêts supplémentaires</h3>
+          <ul>
+            <li>2e arrêt : 5 € TTC</li>
+            <li>3e arrêt : 4 € TTC</li>
+            <li>4e arrêt : 3 € TTC</li>
+            <li>5e arrêt : 4 € TTC</li>
+            <li>6e+ arrêt : 5 € TTC</li>
+          </ul>
+        </div>
+        <div class="pricing__col">
+          <h3>Options</h3>
+          <ul>
+            <li><span class="badge urgent" aria-label="Option Urgent">Urgent</span> : +20 € TTC</li>
+            <li><span class="badge samedi" aria-label="Option Samedi">Samedi</span> : +25 € TTC</li>
+          </ul>
+          <p class="muted">Le samedi est prioritaire sur l’urgent. Une course le samedi applique toujours le tarif samedi, même si elle est urgente.</p>
+        </div>
+      </div>
+      <hr class="sep">
+      <button class="btn" data-open="dlg-proxy" type="button">Déclencher pour un résident</button>
+    </section>
+
+    <!-- Calendrier -->
+    <section class="calendar card" aria-labelledby="tit-cal">
+      <div class="calendar__toolbar">
+        <button class="btn ghost" id="prev-week" aria-label="Semaine précédente" type="button">◀</button>
+        <h2 id="tit-cal">Réservez vos tournées pro en 1 clic</h2>
+        <button class="btn ghost" id="next-week" aria-label="Semaine suivante" type="button">▶</button>
+      </div>
+
+      <div class="weekbar" role="row" id="weekbar">
+        <div aria-hidden="true"></div>
+        <div class="day" role="columnheader" data-day="0">Lun</div>
+        <div class="day" role="columnheader" data-day="1">Mar</div>
+        <div class="day" role="columnheader" data-day="2">Mer</div>
+        <div class="day" role="columnheader" data-day="3">Jeu</div>
+        <div class="day" role="columnheader" data-day="4">Ven</div>
+        <div class="day" role="columnheader" data-day="5">Sam</div>
+        <div class="day" role="columnheader" data-day="6">Dim</div>
+      </div>
+
+      <div id="cal-grid" class="grid" role="grid" aria-describedby="leg-plages">
+        <!-- Colonnes générées par JS -->
+      </div>
+      <p id="leg-plages" class="muted">Créneaux toutes 15 min (journée continue).</p>
+    </section>
+
+    <!-- Panier -->
+    <aside class="card cart" aria-labelledby="tit-panier">
+      <h2 id="tit-panier">Panier de réservation</h2>
+      <p id="cart-empty" class="cart-empty">Votre panier est vide.</p>
+      <ul id="cart-list" class="cart-list"></ul>
+      <div class="cart-total">
+        <span>Total estimé</span>
+        <strong id="cart-total">0,00 €</strong>
+      </div>
+      <div class="cart-actions">
+        <button class="btn secondary" id="btn-valider" type="button">Valider</button>
+        <button class="btn ghost" id="btn-vider" type="button">Vider</button>
+      </div>
+    </aside>
+  </main>
+
+  <!-- Modale Déclenchement par tiers -->
+  <dialog id="dlg-proxy" class="modal card" aria-labelledby="dlg-proxy-title" aria-modal="true">
+    <form id="frm-proxy" method="dialog">
+      <header class="modal__header">
+        <h2 id="dlg-proxy-title">Déclenchement par pharmacien / infirmier</h2>
+        <button class="btn ghost modal__close" data-close type="button" aria-label="Fermer">✕</button>
+      </header>
+      <div class="modal__body">
+        <p class="muted">La modale peut préremplir avec les infos du résident/EHPAD. Vous pouvez modifier si besoin.</p>
+        <fieldset class="field-group">
+          <legend>Résident / EHPAD</legend>
+          <label class="field">
+            <span>Nom du résident</span>
+            <input type="text" name="residentName" required autocomplete="name" />
+          </label>
+          <label class="field">
+            <span>EHPAD / Service</span>
+            <input type="text" name="org" autocomplete="organization" />
+          </label>
+          <label class="field">
+            <span>Téléphone</span>
+            <input type="tel" name="phone" inputmode="tel" autocomplete="tel" />
+          </label>
+          <label class="field">
+            <span>Email</span>
+            <input type="email" name="email" autocomplete="email" />
+          </label>
+        </fieldset>
+
+        <label class="check">
+          <input type="checkbox" id="chk-billing" />
+          <span>Renseigner des <b>coordonnées à facturer</b> différentes</span>
+        </label>
+
+        <fieldset class="field-group" id="billing-fields" hidden>
+          <legend>Coordonnées à facturer</legend>
+          <label class="field">
+            <span>Nom / Raison sociale</span>
+            <input type="text" name="billingName" />
+          </label>
+          <label class="field">
+            <span>Email facturation</span>
+            <input type="email" name="billingEmail" />
+          </label>
+          <label class="field">
+            <span>Référence interne (optionnel)</span>
+            <input type="text" name="billingRef" />
+          </label>
+        </fieldset>
+      </div>
+      <footer class="modal__footer">
+        <button class="btn" value="save" type="submit">Enregistrer</button>
+        <button class="btn ghost" value="cancel" data-close type="button">Annuler</button>
+      </footer>
+    </form>
+  </dialog>
+
+  <!-- Zone notifications -->
+  <div id="toast" role="status" aria-live="polite" class="toast" hidden></div>
+
+  <!-- Scripts -->
+  <script src="./a11y.js"></script>
+  <script src="./app.js"></script>
+</body>
+</html>

--- a/ui/theme.css
+++ b/ui/theme.css
@@ -1,0 +1,140 @@
+/* =========================
+   Design tokens & reset
+   ========================= */
+:root{
+  --els-primary:#8e44ad;
+  --els-primary-600:#7a3c99;
+  --els-accent:#3498db;
+  --els-accent-300:#5dade2;
+  --els-bg:#fafbff;
+  --els-card:#ffffff;
+  --els-text:#1f2a37;
+  --els-muted:#6b7280;
+  --ring:0 0 0 3px rgba(52,152,219,.35);
+  --radius-xl:1rem;
+  --shadow-md:0 8px 24px rgba(2,6,23,.08);
+}
+
+*{box-sizing:border-box}
+html,body{height:100%}
+html,body{
+  font-family:Montserrat,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial,"Noto Sans",sans-serif;
+  color:var(--els-text);
+  background:var(--els-bg);
+  line-height:1.5;
+}
+img{max-width:100%;height:auto}
+button{font:inherit}
+
+/* Utils */
+.muted{color:var(--els-muted)}
+.sep{border:none;height:1px;background:#e5e7eb;margin:1rem 0}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+
+/* =========================
+   Layout
+   ========================= */
+.header{
+  display:flex;align-items:center;justify-content:space-between;gap:1rem;
+  margin:1rem auto;max-width:1200px;
+}
+.header__left{display:flex;align-items:center;gap:.75rem}
+.app-title{font-size:1.1rem}
+
+.layout{
+  display:grid;gap:1rem;grid-template-columns:1fr 320px;
+  align-items:start;max-width:1200px;margin:0 auto 2rem;padding:0 1rem;
+}
+@media (max-width: 960px){
+  .layout{grid-template-columns:1fr}
+  .cart{position:static}
+}
+
+/* =========================
+   Card & Button
+   ========================= */
+.card{
+  background:var(--els-card);
+  border-radius:var(--radius-xl);
+  box-shadow:var(--shadow-md);
+  padding:1rem;
+}
+
+.btn{
+  display:inline-flex;align-items:center;justify-content:center;gap:.5rem;
+  padding:.6rem 1rem;border-radius:999px;border:1px solid transparent;
+  background:var(--els-primary);color:#fff;font-weight:600;cursor:pointer;
+  transition:transform .06s ease, opacity .2s ease, box-shadow .2s ease;
+  box-shadow:var(--shadow-md);
+}
+.btn:hover{transform:translateY(-1px)}
+.btn:active{transform:translateY(0)}
+.btn:focus-visible{outline:none;box-shadow:var(--ring)}
+.btn[disabled]{opacity:.55;pointer-events:none}
+.btn.secondary{background:linear-gradient(90deg,var(--els-accent),var(--els-accent-300))}
+.btn.ghost{background:transparent;color:var(--els-primary);border-color:currentColor}
+
+/* =========================
+   Pricing
+   ========================= */
+#tit-tarifs{margin:0 0 .5rem}
+.pricing{display:grid;grid-template-columns:repeat(3,1fr);gap:1rem}
+.pricing__col h3{margin:.25rem 0 .5rem;font-size:1rem}
+.pricing__col ul{margin:0;padding-left:1.1rem}
+@media (max-width: 720px){ .pricing{grid-template-columns:1fr} }
+
+/* =========================
+   Badges
+   ========================= */
+.badge{
+  display:inline-flex;align-items:center;gap:.35rem;
+  padding:.2rem .6rem;border-radius:999px;font-size:.85rem;font-weight:600;
+}
+.badge.urgent{background:#fff0f1;color:#b42318;border:1px solid #f3b4b7}
+.badge.samedi{background:#eef6ff;color:#1e40af;border:1px solid #c7d2fe}
+.badge.ehpad{background:#f0fdf4;color:#166534;border:1px solid #bbf7d0}
+
+/* =========================
+   Fields
+   ========================= */
+.field-group{display:grid;gap:.75rem;margin:.5rem 0 1rem}
+.field{display:grid;gap:.25rem}
+.field > span{font-weight:600}
+.field input, .field select, .field textarea{
+  width:100%;padding:.6rem .75rem;border-radius:.75rem;border:1px solid #e5e7eb;background:#fff;
+}
+.field input:focus-visible, .field select:focus-visible, .field textarea:focus-visible{
+  outline:none;box-shadow:var(--ring);border-color:#bfdbfe;
+}
+.check{display:flex;align-items:center;gap:.5rem;margin:.5rem 0}
+
+/* =========================
+   Cart
+   ========================= */
+.cart{position:sticky;top:1rem}
+.cart-empty{color:var(--els-muted);font-style:italic}
+.cart-list{display:grid;gap:.5rem;list-style:none;padding:0;margin:.5rem 0}
+.cart-item{display:flex;align-items:center;justify-content:space-between;gap:.5rem;border:1px dashed #e5e7eb;border-radius:.75rem;padding:.5rem .75rem;background:#fff}
+.cart-total{display:flex;align-items:center;justify-content:space-between;margin:.5rem 0;font-size:1.05rem}
+.cart-actions{display:flex;gap:.5rem}
+
+/* =========================
+   Modal (<dialog>)
+   ========================= */
+.modal{max-width:680px;width:100%;border:none;padding:0}
+.modal::backdrop{background:rgba(15,23,42,.45)}
+.modal__header{display:flex;align-items:center;justify-content:space-between;padding:1rem 1rem .5rem .5rem}
+.modal__body{padding:0 1rem 1rem}
+.modal__footer{display:flex;gap:.5rem;justify-content:flex-end;padding:0 1rem 1rem}
+.modal__close{line-height:1;width:40px}
+
+/* =========================
+   Notice / Toast
+   ========================= */
+.notice{
+  max-width:1200px;margin:0 auto 1rem;padding:.75rem 1rem;border:1px solid #e5e7eb;border-radius:.75rem;background:#fff;
+}
+.toast{
+  position:fixed;inset:auto 1rem 1rem auto;min-width:240px;max-width:min(90vw,420px);
+  padding:.75rem 1rem;border-radius:.75rem;background:#111827;color:#fff;box-shadow:var(--shadow-md);z-index:50;
+}


### PR DESCRIPTION
## Summary
- add standalone theme-unique booking UI with 15‑minute continuous calendar
- include accessible dialog helpers and brand assets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbe6b71dc08326b9c4dd5818157dcc