### PR TITLE
Add meta tags and structured data to interfaces

### DIFF
--- a/Admin_Interface.html
+++ b/Admin_Interface.html
@@ -1,11 +1,68 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
+  <? var appUrl = ScriptApp.getService().getUrl(); var nomService = NOM_ENTREPRISE; ?>
   <base target="_top">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Permissions-Policy" content="camera=(), microphone=()" />
-  <title>Tableau de Bord Administrateur</title>
+  <meta name="description" content="Livraison pharmacie à domicile et EHPAD sur Tamaris, Mar Vivo, Six-Fours-les-Plages, Sanary, Portissol et Bandol.">
+  <link rel="canonical" href="<?= appUrl ?>">
+  <meta property="og:title" content="<?= nomService ?> | Tableau de Bord Administrateur">
+  <meta property="og:description" content="Livraison pharmacie à domicile et EHPAD sur Tamaris, Mar Vivo, Six-Fours-les-Plages, Sanary, Portissol et Bandol.">
+  <meta property="og:url" content="<?= appUrl ?>">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="<?= nomService ?> | Tableau de Bord Administrateur">
+  <meta name="twitter:description" content="Livraison pharmacie à domicile et EHPAD sur Tamaris, Mar Vivo, Six-Fours-les-Plages, Sanary, Portissol et Bandol.">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "LocalBusiness",
+        "@id": "<?= appUrl ?>#business",
+        "name": "<?= nomService ?>",
+        "description": "Livraison pharmacie à domicile et EHPAD sur Tamaris, Mar Vivo, Six-Fours-les-Plages, Sanary, Portissol et Bandol.",
+        "url": "<?= appUrl ?>",
+        "email": "<?= EMAIL_ENTREPRISE ?>",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Six-Fours-les-Plages",
+          "addressCountry": "FR"
+        },
+        "geo": {
+          "@type": "GeoCoordinates",
+          "latitude": 43.0842,
+          "longitude": 5.8009
+        },
+        "areaServed": [
+          { "@type": "Place", "name": "Tamaris" },
+          { "@type": "Place", "name": "Mar Vivo" },
+          { "@type": "Place", "name": "Six-Fours-les-Plages" },
+          { "@type": "Place", "name": "Sanary" },
+          { "@type": "Place", "name": "Portissol" },
+          { "@type": "Place", "name": "Bandol" }
+        ]
+      },
+      {
+        "@type": "Service",
+        "@id": "<?= appUrl ?>#service",
+        "serviceType": "Livraison de pharmacie",
+        "provider": { "@id": "<?= appUrl ?>#business" },
+        "areaServed": [
+          { "@type": "Place", "name": "Tamaris" },
+          { "@type": "Place", "name": "Mar Vivo" },
+          { "@type": "Place", "name": "Six-Fours-les-Plages" },
+          { "@type": "Place", "name": "Sanary" },
+          { "@type": "Place", "name": "Portissol" },
+          { "@type": "Place", "name": "Bandol" }
+        ]
+      }
+    ]
+  }
+  </script>
+  <title><?= nomService ?> | Tableau de Bord Administrateur</title>
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/Client_Espace.html
+++ b/Client_Espace.html
@@ -1,11 +1,68 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
+  <? var appUrl = ScriptApp.getService().getUrl(); var nomService = NOM_ENTREPRISE; ?>
   <base target="_top">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Permissions-Policy" content="camera=(), microphone=()" />
-  <title>Mon Espace Client - Vos Réservations</title>
+  <meta name="description" content="Livraison pharmacie à domicile et EHPAD sur Tamaris, Mar Vivo, Six-Fours-les-Plages, Sanary, Portissol et Bandol.">
+  <link rel="canonical" href="<?= appUrl ?>">
+  <meta property="og:title" content="<?= nomService ?> | Mon Espace Client">
+  <meta property="og:description" content="Livraison pharmacie à domicile et EHPAD sur Tamaris, Mar Vivo, Six-Fours-les-Plages, Sanary, Portissol et Bandol.">
+  <meta property="og:url" content="<?= appUrl ?>">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="<?= nomService ?> | Mon Espace Client">
+  <meta name="twitter:description" content="Livraison pharmacie à domicile et EHPAD sur Tamaris, Mar Vivo, Six-Fours-les-Plages, Sanary, Portissol et Bandol.">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "LocalBusiness",
+        "@id": "<?= appUrl ?>#business",
+        "name": "<?= nomService ?>",
+        "description": "Livraison pharmacie à domicile et EHPAD sur Tamaris, Mar Vivo, Six-Fours-les-Plages, Sanary, Portissol et Bandol.",
+        "url": "<?= appUrl ?>",
+        "email": "<?= EMAIL_ENTREPRISE ?>",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Six-Fours-les-Plages",
+          "addressCountry": "FR"
+        },
+        "geo": {
+          "@type": "GeoCoordinates",
+          "latitude": 43.0842,
+          "longitude": 5.8009
+        },
+        "areaServed": [
+          { "@type": "Place", "name": "Tamaris" },
+          { "@type": "Place", "name": "Mar Vivo" },
+          { "@type": "Place", "name": "Six-Fours-les-Plages" },
+          { "@type": "Place", "name": "Sanary" },
+          { "@type": "Place", "name": "Portissol" },
+          { "@type": "Place", "name": "Bandol" }
+        ]
+      },
+      {
+        "@type": "Service",
+        "@id": "<?= appUrl ?>#service",
+        "serviceType": "Livraison de pharmacie",
+        "provider": { "@id": "<?= appUrl ?>#business" },
+        "areaServed": [
+          { "@type": "Place", "name": "Tamaris" },
+          { "@type": "Place", "name": "Mar Vivo" },
+          { "@type": "Place", "name": "Six-Fours-les-Plages" },
+          { "@type": "Place", "name": "Sanary" },
+          { "@type": "Place", "name": "Portissol" },
+          { "@type": "Place", "name": "Bandol" }
+        ]
+      }
+    ]
+  }
+  </script>
+  <title><?= nomService ?> | Mon Espace Client</title>
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/Debug_Interface.html
+++ b/Debug_Interface.html
@@ -1,12 +1,69 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-    <base target="_top">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Permissions-Policy" content="camera=(), microphone=()" />
-    <title>Panneau de Débogage</title>
-    <style>
+  <? var appUrl = ScriptApp.getService().getUrl(); var nomService = NOM_ENTREPRISE; ?>
+  <base target="_top">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Permissions-Policy" content="camera=(), microphone=()" />
+  <meta name="description" content="Livraison pharmacie à domicile et EHPAD sur Tamaris, Mar Vivo, Six-Fours-les-Plages, Sanary, Portissol et Bandol.">
+  <link rel="canonical" href="<?= appUrl ?>">
+  <meta property="og:title" content="<?= nomService ?> | Panneau de Débogage">
+  <meta property="og:description" content="Livraison pharmacie à domicile et EHPAD sur Tamaris, Mar Vivo, Six-Fours-les-Plages, Sanary, Portissol et Bandol.">
+  <meta property="og:url" content="<?= appUrl ?>">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="<?= nomService ?> | Panneau de Débogage">
+  <meta name="twitter:description" content="Livraison pharmacie à domicile et EHPAD sur Tamaris, Mar Vivo, Six-Fours-les-Plages, Sanary, Portissol et Bandol.">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "LocalBusiness",
+        "@id": "<?= appUrl ?>#business",
+        "name": "<?= nomService ?>",
+        "description": "Livraison pharmacie à domicile et EHPAD sur Tamaris, Mar Vivo, Six-Fours-les-Plages, Sanary, Portissol et Bandol.",
+        "url": "<?= appUrl ?>",
+        "email": "<?= EMAIL_ENTREPRISE ?>",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Six-Fours-les-Plages",
+          "addressCountry": "FR"
+        },
+        "geo": {
+          "@type": "GeoCoordinates",
+          "latitude": 43.0842,
+          "longitude": 5.8009
+        },
+        "areaServed": [
+          { "@type": "Place", "name": "Tamaris" },
+          { "@type": "Place", "name": "Mar Vivo" },
+          { "@type": "Place", "name": "Six-Fours-les-Plages" },
+          { "@type": "Place", "name": "Sanary" },
+          { "@type": "Place", "name": "Portissol" },
+          { "@type": "Place", "name": "Bandol" }
+        ]
+      },
+      {
+        "@type": "Service",
+        "@id": "<?= appUrl ?>#service",
+        "serviceType": "Livraison de pharmacie",
+        "provider": { "@id": "<?= appUrl ?>#business" },
+        "areaServed": [
+          { "@type": "Place", "name": "Tamaris" },
+          { "@type": "Place", "name": "Mar Vivo" },
+          { "@type": "Place", "name": "Six-Fours-les-Plages" },
+          { "@type": "Place", "name": "Sanary" },
+          { "@type": "Place", "name": "Portissol" },
+          { "@type": "Place", "name": "Bandol" }
+        ]
+      }
+    ]
+  }
+  </script>
+  <title><?= nomService ?> | Panneau de Débogage</title>
+  <style>
         body { font-family: Montserrat, sans-serif; margin: 20px; background-color: #0b0e13; color: #fff; }
         h1 { color: #fff; }
         .test-suite { background-color: #0f151f; border: 1px solid #1d2a3a; border-radius: 5px; padding: 15px; margin-bottom: 15px; }

--- a/Infos_confidentialite.html
+++ b/Infos_confidentialite.html
@@ -1,10 +1,67 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
+  <? var appUrl = ScriptApp.getService().getUrl(); var nomService = NOM_ENTREPRISE; ?>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta http-equiv="Permissions-Policy" content="camera=(), microphone=()" />
-  <title>Infos & confidentialité | EL Services Littoral</title>
+  <meta name="description" content="Livraison pharmacie à domicile et EHPAD sur Tamaris, Mar Vivo, Six-Fours-les-Plages, Sanary, Portissol et Bandol.">
+  <link rel="canonical" href="<?= appUrl ?>">
+  <meta property="og:title" content="<?= nomService ?> | Infos & confidentialité">
+  <meta property="og:description" content="Livraison pharmacie à domicile et EHPAD sur Tamaris, Mar Vivo, Six-Fours-les-Plages, Sanary, Portissol et Bandol.">
+  <meta property="og:url" content="<?= appUrl ?>">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="<?= nomService ?> | Infos & confidentialité">
+  <meta name="twitter:description" content="Livraison pharmacie à domicile et EHPAD sur Tamaris, Mar Vivo, Six-Fours-les-Plages, Sanary, Portissol et Bandol.">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "LocalBusiness",
+        "@id": "<?= appUrl ?>#business",
+        "name": "<?= nomService ?>",
+        "description": "Livraison pharmacie à domicile et EHPAD sur Tamaris, Mar Vivo, Six-Fours-les-Plages, Sanary, Portissol et Bandol.",
+        "url": "<?= appUrl ?>",
+        "email": "<?= EMAIL_ENTREPRISE ?>",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Six-Fours-les-Plages",
+          "addressCountry": "FR"
+        },
+        "geo": {
+          "@type": "GeoCoordinates",
+          "latitude": 43.0842,
+          "longitude": 5.8009
+        },
+        "areaServed": [
+          { "@type": "Place", "name": "Tamaris" },
+          { "@type": "Place", "name": "Mar Vivo" },
+          { "@type": "Place", "name": "Six-Fours-les-Plages" },
+          { "@type": "Place", "name": "Sanary" },
+          { "@type": "Place", "name": "Portissol" },
+          { "@type": "Place", "name": "Bandol" }
+        ]
+      },
+      {
+        "@type": "Service",
+        "@id": "<?= appUrl ?>#service",
+        "serviceType": "Livraison de pharmacie",
+        "provider": { "@id": "<?= appUrl ?>#business" },
+        "areaServed": [
+          { "@type": "Place", "name": "Tamaris" },
+          { "@type": "Place", "name": "Mar Vivo" },
+          { "@type": "Place", "name": "Six-Fours-les-Plages" },
+          { "@type": "Place", "name": "Sanary" },
+          { "@type": "Place", "name": "Portissol" },
+          { "@type": "Place", "name": "Bandol" }
+        ]
+      }
+    ]
+  }
+  </script>
+  <title><?= nomService ?> | Infos & confidentialité</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- enrich admin, client, info and debug interfaces with meta description, canonical link, OpenGraph/Twitter tags
- embed LocalBusiness/Service JSON-LD blocks
- ensure each page exposes a descriptive title

## Testing
- `npm test`
- `npm run test:clasp` *(fails: unknown option '--noninteractive')*
- `curl -s -o /tmp/googletest.html -w "%{http_code}\n" "https://search.google.com/test/rich-results?url=https://example.com"`


------
https://chatgpt.com/codex/tasks/task_e_68bc0622d72c8326be7f4fca140902f0