### PR TITLE
fix: externalise debug styles

### DIFF
--- a/Debug_CSS.html
+++ b/Debug_CSS.html
@@ -1,0 +1,10 @@
+<style>
+  body { font-family: var(--font); margin: 20px; background-color: var(--bg); color: var(--txt); }
+  h1 { color: var(--txt); }
+  .test-suite { background-color: var(--bg-alt); border: 1px solid var(--bordure-fonce); border-radius: 5px; padding: 15px; margin-bottom: 15px; }
+  button { background: var(--grad); color: var(--txt); border: none; padding: 10px 18px; border-radius: var(--radius-pill); cursor: pointer; margin-right: 10px; box-shadow: var(--shadow); transition: transform .08s ease, box-shadow .2s ease; }
+  button:hover { transform: translateY(-1px); }
+  button:focus { outline: 2px solid var(--bleu); outline-offset: 2px; }
+  button:active { transform: translateY(0); }
+  #results { margin-top: 20px; background-color: var(--bg-panel); color: var(--txt); padding: 15px; border-radius: 5px; white-space: pre-wrap; font-family: monospace; height: 400px; overflow-y: scroll; }
+</style>

--- a/Debug_Interface.html
+++ b/Debug_Interface.html
@@ -6,16 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=()" />
     <title>Panneau de Débogage</title>
-    <style>
-        body { font-family: Montserrat, sans-serif; margin: 20px; background-color: #0b0e13; color: #fff; }
-        h1 { color: #fff; }
-        .test-suite { background-color: #0f151f; border: 1px solid #1d2a3a; border-radius: 5px; padding: 15px; margin-bottom: 15px; }
-        button { background: linear-gradient(135deg, #8e44ad, #3498db); color: #fff; border: none; padding: 10px 18px; border-radius: 9999px; cursor: pointer; margin-right: 10px; box-shadow: 0 6px 18px rgba(0,0,0,.18); transition: transform .08s ease, box-shadow .2s ease; }
-        button:hover { transform: translateY(-1px); }
-        button:focus { outline: 2px solid #3498db; outline-offset: 2px; }
-        button:active { transform: translateY(0); }
-        #results { margin-top: 20px; background-color: #101724; color: #fff; padding: 15px; border-radius: 5px; white-space: pre-wrap; font-family: monospace; height: 400px; overflow-y: scroll; }
-    </style>
+    <?!= include('Debug_CSS'); ?>
   <?!= include('charte'); ?>
 </head>
 <body>
@@ -31,12 +22,12 @@
     <h3>Générer un lien Espace Client</h3>
     <p>Crée un lien signé pour accéder à l'espace client (admin requis).</p>
     <div style="display:flex; gap:10px; flex-wrap:wrap; align-items:center">
-      <input type="email" id="email-client" placeholder="client@example.com" style="flex:1; min-width:260px; padding:8px; border-radius:6px; border:1px solid #1d2a3a; background:#0b0e13; color:#fff">
-      <input type="number" id="validite-heures" value="168" min="1" step="1" style="width:120px; padding:8px; border-radius:6px; border:1px solid #1d2a3a; background:#0b0e13; color:#fff">
+      <input type="email" id="email-client" placeholder="client@example.com" style="flex:1; min-width:260px; padding:8px; border-radius:6px; border:1px solid var(--bordure-fonce); background:var(--bg); color:var(--txt)">
+      <input type="number" id="validite-heures" value="168" min="1" step="1" style="width:120px; padding:8px; border-radius:6px; border:1px solid var(--bordure-fonce); background:var(--bg); color:var(--txt)">
       <button id="btn-generer">Générer</button>
     </div>
     <div id="zone-lien" style="margin-top:10px; display:none">
-      <input type="text" id="lien-resultat" readonly style="width:100%; padding:8px; border-radius:6px; border:1px solid #1d2a3a; background:#0b0e13; color:#fff">
+      <input type="text" id="lien-resultat" readonly style="width:100%; padding:8px; border-radius:6px; border:1px solid var(--bordure-fonce); background:var(--bg); color:var(--txt)">
       <div style="margin-top:8px"><button id="btn-copier">Copier</button></div>
     </div>
   </div>

--- a/Styles.html
+++ b/Styles.html
@@ -5,6 +5,9 @@
   --bleu-clair:#5dade2;
   --txt:#ffffff;
   --bg:#0b0e13;
+  --bg-alt:#0f151f;
+  --bg-panel:#101724;
+  --bordure-fonce:#1d2a3a;
   --muted:#9fb3c8;
   --radius:12px;
   --radius-pill:9999px;


### PR DESCRIPTION
## Summary
- factor debug CSS into `Debug_CSS.html` and include from interface
- use theme variables for debug panel colors and button gradient

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc0628b3f48326a9a78f243b8dcf38