### PR TITLE
Debug: ajoute préconnexion Google Fonts avant charte

### DIFF
--- a/Debug_Interface.html
+++ b/Debug_Interface.html
@@ -63,6 +63,9 @@
   }
   </script>
   <title><?= nomService ?> | Panneau de Débogage</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>
         body { font-family: Montserrat, sans-serif; margin: 20px; background-color: #0b0e13; color: #fff; }
         h1 { color: #fff; }


### PR DESCRIPTION
## Summary
- ensure Google Fonts preconnect lines appear before `include('charte')` in Debug interface head

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc14dde0ec8326b386df56bec7720a