### PR TITLE
feat: add pricing rules flag

### DIFF
--- a/Configuration.gs
+++ b/Configuration.gs
@@ -115,6 +115,8 @@ const RESIDENT_BILLING_ENABLED = true;
 const BILLING_MODAL_ENABLED = true;
 /** @const {boolean} Inclut le retour dans la durée et la distance estimées (UI uniquement). */
 const RETURN_IMPACTS_ESTIMATES_ENABLED = false;
+/** @const {boolean} Apply pricing rules V2 (Saturday overrides urgent; no stacking). */
+const PRICING_RULES_V2_ENABLED = false;
 
 // --- Drapeaux de Débogage et de Test ---
 /** @const {boolean} Affiche le sous-menu Debug et l'interface associée. */
@@ -286,6 +288,4 @@ function getConfigCached() {
   // Met en cache la configuration pour 10 minutes (600 secondes)
   cache.put('CONFIG_JSON', JSON.stringify(config), 600);
   return config;
-/** @const {boolean} Apply pricing rules V2 (Saturday overrides urgent; no stacking). */
-const PRICING_RULES_V2_ENABLED = false;
 }


### PR DESCRIPTION
## Summary
- add `PRICING_RULES_V2_ENABLED` to feature flag block in Configuration
- remove stray flag declaration from `getConfigCached`

## Testing
- `npm test`
- `npm run test:clasp` *(fails: unknown option '--noninteractive')*
- `npm run clasp:push` *(fails: Could not read API credentials)*
- `npm run clasp:deploy` *(fails: Cannot find module 'tools/deploy.js')*

------
https://chatgpt.com/codex/tasks/task_e_68bd9740e074832695ba45f03a94c269