### PR TITLE
feat: allow cart reset [flag:CART_RESET_ENABLED]

### DIFF
--- a/Configuration.gs
+++ b/Configuration.gs
@@ -113,6 +113,8 @@ const RESIDENT_BILLING_ENABLED = true;
 
 /** @const {boolean} Active la modale de coordonnées de facturation. */
 const BILLING_MODAL_ENABLED = true;
+/** @const {boolean} Active la réinitialisation du panier côté client. */
+const CART_RESET_ENABLED = false;
 /** @const {boolean} Inclut le retour dans la durée et la distance estimées (UI uniquement). */
 const RETURN_IMPACTS_ESTIMATES_ENABLED = false;
 /** @const {boolean} Apply pricing rules V2 (Saturday overrides urgent; no stacking). */
@@ -157,6 +159,7 @@ const FLAGS = Object.freeze({
   reservationUiV2Enabled: RESERVATION_UI_V2_ENABLED,
   residentBillingEnabled: RESIDENT_BILLING_ENABLED,
   billingModalEnabled: BILLING_MODAL_ENABLED,
+  cartResetEnabled: CART_RESET_ENABLED,
   debugMenuEnabled: DEBUG_MENU_ENABLED,
   demoReservationEnabled: DEMO_RESERVATION_ENABLED,
   billingV2Dryrun: BILLING_V2_DRYRUN,

--- a/Reservation_Interface.html
+++ b/Reservation_Interface.html
@@ -178,6 +178,7 @@
               <strong id="panier-total-valeur">0 €</strong>
             </div>
             <div class="panier-actions-groupe">
+                <button id="btn-vider-panier" class="btn btn-secondaire" aria-label="Vider le panier">Vider le panier</button>
                 <button id="btn-envoyer-devis" class="btn btn-secondaire">Recevoir un devis</button>
                 <button id="btn-valider-panier" class="btn btn-primaire">Valider le panier</button>
             </div>

--- a/Reservation_JS_Panier.html
+++ b/Reservation_JS_Panier.html
@@ -147,5 +147,21 @@ function chargerPanierDepuisLocalStorage() {
     afficherPanier();
   }
 }
+
+/**
+ * Vide complètement le panier et restaure les disponibilités.
+ */
+function viderPanier() {
+  const { panier } = window.etat;
+  panier.forEach(item => {
+    if (typeof ajusterDisponibiliteJour === 'function') {
+      try { ajusterDisponibiliteJour(item.date, +1); } catch (err) {}
+    }
+  });
+  window.etat.panier = [];
+  sauvegarderPanierDansLocalStorage();
+  afficherPanier();
+  afficherNotification("Panier vidé.", "info");
+}
 </script>
 

--- a/Reservation_JS_Principal.html
+++ b/Reservation_JS_Principal.html
@@ -34,6 +34,7 @@ function initializeFlags(flags = {}) {
     configCacheEnabled: false,
     reservationCacheEnabled: false,
     themeV2Enabled: false,
+    cartResetEnabled: false,
     devisEnabled: false
 
   };
@@ -407,6 +408,12 @@ function configurerEcouteursEvenements() {
   ui.formulaireReservation?.addEventListener('submit', gererSoumissionReservation);
   ui.btnAnnulerReservation?.addEventListener('click', () => ui.conteneurFinalisation.classList.add('hidden'));
   ui.listePanier?.addEventListener('click', gererActionsPanier);
+
+  if (window.etat.flags.cartResetEnabled) {
+    ui.btnViderPanier?.addEventListener('click', viderPanier);
+  } else {
+    ui.btnViderPanier?.classList.add('hidden');
+  }
 
   window.addEventListener('billing:saved', () => {
     afficherNotification('Coordonnées de facturation enregistrées.', 'succes');

--- a/Reservation_JS_UI_Elements.html
+++ b/Reservation_JS_UI_Elements.html
@@ -23,6 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
     listePanier: document.getElementById('liste-panier'),
     panierPiedDePage: document.getElementById('panier-pied-de-page'),
     panierTotalValeur: document.getElementById('panier-total-valeur'),
+    btnViderPanier: document.getElementById('btn-vider-panier'),
     btnValiderPanier: document.getElementById('btn-valider-panier'),
 
     // Modale 1: Configuration de la tournée


### PR DESCRIPTION
## Summary
- add CART_RESET_ENABLED flag and expose via FLAGS object
- add "Vider le panier" button and UI references
- implement viderPanier logic and event binding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd9a02a3688326abc350f17f0c5c61