### PR TITLE
fix: defer event listeners until config

### DIFF
--- a/Reservation_JS_Principal.html
+++ b/Reservation_JS_Principal.html
@@ -410,6 +410,7 @@ function configurerEcouteursEvenements() {
   ui.listePanier?.addEventListener('click', gererActionsPanier);
 
   if (window.etat.flags.cartResetEnabled) {
+    ui.btnViderPanier?.classList.remove('hidden');
     ui.btnViderPanier?.addEventListener('click', viderPanier);
   } else {
     ui.btnViderPanier?.classList.add('hidden');
@@ -449,11 +450,11 @@ function configurerEcouteursEvenements() {
 document.addEventListener('DOMContentLoaded', () => {
   google.script.run.withSuccessHandler(cfg => {
     window.etat.flags = initializeFlags(cfg);
+    configurerEcouteursEvenements();
   }).getConfiguration();
   chargerPanierDepuisLocalStorage();
   verifierSessionClient();
   afficherCalendrier(window.etat.dateActuelle.getMonth() + 1, window.etat.dateActuelle.getFullYear());
-  configurerEcouteursEvenements();
 });
 
 /**


### PR DESCRIPTION
## Summary
- load configuration before wiring up event listeners
- ensure empty-cart button shows when CART_RESET_ENABLED is active

## Testing
- `npm test`
- `npm run test:clasp` *(fails: unknown option '--noninteractive')*

------
https://chatgpt.com/codex/tasks/task_e_68bda27269cc8326833875a97115563c