### PR TITLE
feat: add social proof block under tariffs

### DIFF
--- a/Configuration.gs
+++ b/Configuration.gs
@@ -120,6 +120,9 @@ const RETURN_IMPACTS_ESTIMATES_ENABLED = false;
 /** @const {boolean} Apply pricing rules V2 (Saturday overrides urgent; no stacking). */
 const PRICING_RULES_V2_ENABLED = false;
 
+/** @const {boolean} Affiche le bloc de preuves sociales (avis/partenaires). */
+const PROOF_SOCIAL_ENABLED = false;
+
 // --- Drapeaux de Débogage et de Test ---
 /** @const {boolean} Affiche le sous-menu Debug et l'interface associée. */
 const DEBUG_MENU_ENABLED = true;
@@ -167,6 +170,7 @@ const FLAGS = Object.freeze({
   postEndpointEnabled: POST_ENDPOINT_ENABLED,
   configCacheEnabled: CONFIG_CACHE_ENABLED,
   reservationCacheEnabled: RESERVATION_CACHE_ENABLED,
+  proofSocialEnabled: PROOF_SOCIAL_ENABLED,
   themeV2Enabled: THEME_V2_ENABLED,
   pricingRulesV2Enabled: PRICING_RULES_V2_ENABLED,
   returnImpactsEstimatesEnabled: RETURN_IMPACTS_ESTIMATES_ENABLED

--- a/Reservation_CSS.html
+++ b/Reservation_CSS.html
@@ -88,6 +88,33 @@ body {
   line-height: 1.4;
 }
 
+/* --- PREUVES SOCIALES --- */
+.preuves-sociales {
+  margin: 2rem auto;
+  max-width: 800px;
+  background: var(--bg);
+  border: 1px solid var(--bleu);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+  text-align: center;
+}
+.preuves-sociales h2 {
+  margin-top: 0;
+  color: var(--violet);
+}
+.preuves-sociales .avis-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+}
+.preuves-sociales .avis-list li {
+  margin: 0.5rem 0;
+}
+.preuves-sociales .avis-list li strong {
+  color: var(--bleu-clair);
+}
+
 
 /* --- COMPOSANT CARTE --- */
 .carte {

--- a/Reservation_Interface.html
+++ b/Reservation_Interface.html
@@ -151,6 +151,16 @@
       </p>
     </section>
 
+    <? if (PROOF_SOCIAL_ENABLED) { ?>
+    <section class="preuves-sociales" aria-labelledby="preuves-sociales-titre" role="region">
+      <h2 id="preuves-sociales-titre">Ils nous font confiance</h2>
+      <ul class="avis-list">
+        <li><strong>Pharmacie de Tamaris</strong> : « Service rapide et sécurisé »</li>
+        <li><strong>EHPAD Les Amandiers</strong> : « Livraisons fiables pour nos résidents »</li>
+      </ul>
+    </section>
+    <? } ?>
+
     <!-- Script supprimé : les cartes tarifs sont désormais générées côté serveur -->
 
     <main id="app-conteneur" role="main" aria-label="Contenu principal de la page de réservation">


### PR DESCRIPTION
## Summary
- add PROOF_SOCIAL_ENABLED feature flag
- show partner reviews under tariffs when flag enabled
- style social proof block with brand palette

## Testing
- `npm test`
- `npm run test:clasp` *(fails: unknown option '--noninteractive')*

------
https://chatgpt.com/codex/tasks/task_e_68bdaa0bc87883268ec5cbb9129f7c6a