### PR TITLE
feat: add pill icon to hero

### DIFF
--- a/Reservation_CSS.html
+++ b/Reservation_CSS.html
@@ -50,6 +50,17 @@ body {
   margin-top: 0;
   font-size: 1.8em;
 }
+.hero-titre {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+}
+.hero-icone {
+  width: 48px;
+  height: 48px;
+  flex-shrink: 0;
+}
 .hero-tarifs .hero-sous-titre {
   margin: 0.5rem 0 1.5rem;
   font-weight: 500;

--- a/Reservation_Interface.html
+++ b/Reservation_Interface.html
@@ -116,7 +116,10 @@
     </header>
 
     <section id="hero-tarifs" class="hero-tarifs">
-      <h1>Réservez vos tournées pro en 1 clic sur Tamaris, Mar Vivo, Six-Fours-les-Plages, Sanary, Portissol, Bandol</h1>
+      <div class="hero-titre">
+        <img src="icone-gelule.svg" class="hero-icone" role="img" aria-label="Gélule de pharmacie" alt="">
+        <h1>Réservez vos tournées pro en 1 clic sur Tamaris, Mar Vivo, Six-Fours-les-Plages, Sanary, Portissol, Bandol</h1>
+      </div>
       <p class="hero-sous-titre">Tarifs et options toujours à jour, ajustables selon vos besoins.</p>
       <div class="tarifs-cartes">
         <div class="tarif-carte">

--- a/icone-gelule.svg
+++ b/icone-gelule.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" role="img" aria-label="Gélule de pharmacie">
+  <defs>
+    <linearGradient id="geluleGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#8e44ad" />
+      <stop offset="100%" stop-color="#3498db" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="12" width="40" height="24" rx="12" fill="url(#geluleGradient)" />
+  <line x1="24" y1="12" x2="24" y2="36" stroke="#ffffff" stroke-width="2" />
+</svg>


### PR DESCRIPTION
## Summary
- add branded pill SVG icon
- display pill icon left of hero title with aria-label
- style hero header with flex layout for icon and text

## Testing
- `npm test`
- `npm run test:clasp` *(fails: unknown option '--noninteractive')*

------
https://chatgpt.com/codex/tasks/task_e_68bdaa111e888326a230a2779b3e550a