### PR TITLE
feat: enrichir icône gélule du hero

### DIFF
--- a/Reservation_Interface.html
+++ b/Reservation_Interface.html
@@ -118,7 +118,7 @@
 
     <section id="hero-tarifs" class="hero-tarifs">
       <div class="hero-titre">
-        <img src="icone-gelule.svg" class="hero-icone" role="img" aria-label="Gélule de pharmacie" alt="">
+        <img src="icone-gelule.svg" width="48" height="48" class="hero-icone" role="img" aria-label="Gélule de pharmacie" alt="Gélule de pharmacie">
         <h1>Réservez vos tournées pro en 1 clic sur Tamaris, Mar Vivo, Six-Fours-les-Plages, Sanary, Portissol, Bandol</h1>
       </div>
       <p class="hero-sous-titre">Tarifs et options toujours à jour, ajustables selon vos besoins.</p>


### PR DESCRIPTION
## Summary
- improve capsule hero icon with explicit alt text, role and dimensions for accessibility

## Testing
- `npm test`
- `npm run test:clasp` *(fails: unknown option --noninteractive)*

------
https://chatgpt.com/codex/tasks/task_e_68bdaee964688326bae150a17108b8cb