### PR TITLE
feat: add pro Q&A module

### DIFF
--- a/Client_Espace.html
+++ b/Client_Espace.html
@@ -107,6 +107,17 @@
           <!-- Les factures seront injectées ici par le script JS -->
         </div>
       </div>
+      <? if (typeof PRO_QA_ENABLED !== 'undefined' && PRO_QA_ENABLED) { ?>
+      <div id="bloc-questions" class="carte">
+        <h3>Vos questions</h3>
+        <div id="liste-questions" aria-live="polite"></div>
+        <form id="form-question" class="groupe-formulaire" autocomplete="off">
+          <label for="question-texte">Posez votre question</label>
+          <input type="text" id="question-texte" class="champ-formulaire" required aria-required="true">
+          <button type="submit" class="btn btn-primaire btn--client" style="margin-top:10px;">Envoyer</button>
+        </form>
+      </div>
+      <? } ?>
       <div class="carte">
         <p>Pour toute annulation ou pour une modification non disponible ici, veuillez nous contacter directement.</p>
         <a href="<?= ScriptApp.getService().getUrl() ?>" class="btn btn-secondaire btn--client">Faire une nouvelle réservation</a>

--- a/Client_JS.html
+++ b/Client_JS.html
@@ -34,10 +34,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const formulaireConnexionClient = document.getElementById('formulaire-connexion-client');
     const emailConnexionInput = document.getElementById('email-connexion');
     const erreurConnexionDiv = document.getElementById('erreur-connexion');
+    const listeQuestions = document.getElementById('liste-questions');
+    const formQuestion = document.getElementById('form-question');
+    const questionTexte = document.getElementById('question-texte');
 
     // --- Variable d'état pour stocker les réservations chargées ---
     let toutesLesReservationsClient = [];
     let toutesLesFacturesClient = [];
+    let emailClientCourant = '';
 
     /**
      * Initialise l'espace client.
@@ -56,6 +60,13 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (email) {
                     validerEtChargerClient(email);
                 }
+            });
+        }
+
+        if (formQuestion) {
+            formQuestion.addEventListener('submit', (e) => {
+                e.preventDefault();
+                posterQuestion();
             });
         }
     }
@@ -88,8 +99,12 @@ document.addEventListener('DOMContentLoaded', () => {
                     document.getElementById('message-bienvenue-client').textContent = `Bienvenue, ${reponse.client.nom}`;
                     document.getElementById('conteneur-app').classList.remove('hidden');
                     document.getElementById('non-connecte').classList.add('hidden');
+                    emailClientCourant = email;
                     chargerReservationsClient(email);
                     chargerFacturesClient(email);
+                    if (typeof PRO_QA_ENABLED !== 'undefined' && PRO_QA_ENABLED) {
+                        chargerQuestions();
+                    }
                 } else {
                     afficherErreurConnexion(reponse.error);
                     basculerIndicateurChargement(false);
@@ -199,6 +214,57 @@ document.addEventListener('DOMContentLoaded', () => {
             })
             .withFailureHandler(afficherErreur)
             .envoyerFactureClient(email, numero);
+    }
+
+    /**
+     * Charge et affiche les questions du client.
+     */
+    function chargerQuestions() {
+        if (!listeQuestions) return;
+        renderText(listeQuestions, '');
+        google.script.run
+            .withSuccessHandler(qs => {
+                if (qs && qs.length > 0) {
+                    const html = qs.map(q => {
+                        const repHtml = q.reponses && q.reponses.length
+                            ? '<ul>' + q.reponses.map(r => `<li>${escapeHTML(r.auteur)}: ${escapeHTML(r.texte)}</li>`).join('') + '</ul>'
+                            : '';
+                        return `<div class="question-item"><p><strong>${escapeHTML(q.auteur)}:</strong> ${escapeHTML(q.question)}</p>${repHtml}</div>`;
+                    }).join('');
+                    renderHTML(listeQuestions, html);
+                } else {
+                    renderMessage(listeQuestions, 'Aucune question pour le moment.');
+                }
+            })
+            .withFailureHandler(afficherErreur)
+            .getQuestions();
+    }
+
+    function posterQuestion() {
+        if (!questionTexte) return;
+        const texte = questionTexte.value.trim();
+        if (!texte || !emailClientCourant) return;
+        basculerIndicateurChargement(true);
+        google.script.run
+            .withSuccessHandler(() => {
+                questionTexte.value = '';
+                chargerQuestions();
+                basculerIndicateurChargement(false);
+            })
+            .withFailureHandler(afficherErreur)
+            .addQuestion(texte, emailClientCourant);
+    }
+
+    function posterReponse(questionId, reponse) {
+        if (!questionId || !reponse || !emailClientCourant) return;
+        basculerIndicateurChargement(true);
+        google.script.run
+            .withSuccessHandler(() => {
+                chargerQuestions();
+                basculerIndicateurChargement(false);
+            })
+            .withFailureHandler(afficherErreur)
+            .addAnswer(questionId, reponse, emailClientCourant);
     }
 
     /**

--- a/Configuration.gs
+++ b/Configuration.gs
@@ -60,6 +60,8 @@ const SHEET_PLAGES_BLOQUEES = 'Plages_Bloquees';
 const SHEET_RESERVATIONS = 'Réservations';
 /** @const {string} Feuille par défaut des nouveaux classeurs. */
 const SHEET_DEFAULT = 'Sheet1';
+/** @const {string} Feuille stockant les questions des professionnels. */
+const SHEET_QUESTIONS = 'Questions';
 
 // --- Horaires & Tampons ---
 /** @const {string} Heure d'ouverture du service au format HH:MM. */
@@ -122,6 +124,8 @@ const PRICING_RULES_V2_ENABLED = false;
 
 /** @const {boolean} Affiche le bloc de preuves sociales (avis/partenaires). */
 const PROOF_SOCIAL_ENABLED = true;
+/** @const {boolean} Active le module Questions/Réponses pour les professionnels. */
+const PRO_QA_ENABLED = false;
 
 // --- Drapeaux de Débogage et de Test ---
 /** @const {boolean} Affiche le sous-menu Debug et l'interface associée. */
@@ -171,6 +175,7 @@ const FLAGS = Object.freeze({
   configCacheEnabled: CONFIG_CACHE_ENABLED,
   reservationCacheEnabled: RESERVATION_CACHE_ENABLED,
   proofSocialEnabled: PROOF_SOCIAL_ENABLED,
+  proQaEnabled: PRO_QA_ENABLED,
   themeV2Enabled: THEME_V2_ENABLED,
   pricingRulesV2Enabled: PRICING_RULES_V2_ENABLED,
   returnImpactsEstimatesEnabled: RETURN_IMPACTS_ESTIMATES_ENABLED

--- a/Questions.gs
+++ b/Questions.gs
@@ -1,0 +1,67 @@
+// =================================================================
+//                        MODULE QUESTIONS/RÉPONSES
+// =================================================================
+// Description: Gère les questions et réponses des professionnels.
+// =================================================================
+
+/**
+ * Retourne la feuille de stockage des questions, en la créant si nécessaire.
+ * @returns {GoogleAppsScript.Spreadsheet.Sheet} Feuille des questions.
+ */
+function getQuestionsSheet_() {
+  const ss = SpreadsheetApp.openById(getSecret('ID_FEUILLE_CALCUL'));
+  return ss.getSheetByName(SHEET_QUESTIONS) || ss.insertSheet(SHEET_QUESTIONS);
+}
+
+/**
+ * Récupère toutes les questions et leurs réponses.
+ * @returns {Array<Object>} Liste des questions.
+ */
+function getQuestions() {
+  const sheet = getQuestionsSheet_();
+  const data = sheet.getDataRange().getValues();
+  const questions = [];
+  for (let i = 1; i < data.length; i++) {
+    const row = data[i];
+    const id = row[0];
+    const question = row[1];
+    const auteur = row[2];
+    const reponses = row[3] ? JSON.parse(row[3]) : [];
+    questions.push({ id: id, question: question, auteur: auteur, reponses: reponses });
+  }
+  return questions;
+}
+
+/**
+ * Ajoute une nouvelle question.
+ * @param {string} question Texte de la question.
+ * @param {string} auteur Auteur de la question.
+ * @returns {{success:boolean,id:number}} Résultat de l'opération.
+ */
+function addQuestion(question, auteur) {
+  const sheet = getQuestionsSheet_();
+  const id = Date.now();
+  sheet.appendRow([id, question, auteur, JSON.stringify([])]);
+  return { success: true, id: id };
+}
+
+/**
+ * Ajoute une réponse à une question existante.
+ * @param {number|string} questionId Identifiant de la question.
+ * @param {string} reponse Texte de la réponse.
+ * @param {string} auteur Auteur de la réponse.
+ * @returns {{success:boolean}|{success:boolean,error:string}} Résultat.
+ */
+function addAnswer(questionId, reponse, auteur) {
+  const sheet = getQuestionsSheet_();
+  const data = sheet.getDataRange().getValues();
+  for (let i = 1; i < data.length; i++) {
+    if (String(data[i][0]) === String(questionId)) {
+      const reponses = data[i][3] ? JSON.parse(data[i][3]) : [];
+      reponses.push({ auteur: auteur, texte: reponse });
+      sheet.getRange(i + 1, 4).setValue(JSON.stringify(reponses));
+      return { success: true };
+    }
+  }
+  return { success: false, error: 'Question introuvable.' };
+}


### PR DESCRIPTION
## Summary
- add `PRO_QA_ENABLED` feature flag and expose via `FLAGS`
- introduce client Q&A card and logic gated by flag
- implement server-side storage for professional questions

## Testing
- `npm test`
- `npm run test:clasp` *(fails: unknown option '--noninteractive')*

------
https://chatgpt.com/codex/tasks/task_e_68bdb4c5d190832692495173416fd261