### PR TITLE
feat: enforce signed client portal links with TTL

### DIFF
--- a/Client_Espace.html
+++ b/Client_Espace.html
@@ -155,6 +155,14 @@
       document.querySelectorAll('.theme-selector, #btn-theme, #menu-theme').forEach(el => el && el.remove());
     });
   </script>
+  <script>
+    const params = new URLSearchParams(window.location.search);
+    window.CLIENT_PARAMS = {
+      email: params.get('email') || '',
+      exp: params.get('exp') || '',
+      sig: params.get('sig') || ''
+    };
+  </script>
   <?!= include('Render_JS'); ?>
   <?!= include('Client_JS'); ?>
 </body>

--- a/Client_JS.html
+++ b/Client_JS.html
@@ -37,11 +37,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const listeQuestions = document.getElementById('liste-questions');
     const formQuestion = document.getElementById('form-question');
     const questionTexte = document.getElementById('question-texte');
+    const linkEmail = (window.CLIENT_PARAMS && window.CLIENT_PARAMS.email) || '';
+    const linkExp = (window.CLIENT_PARAMS && window.CLIENT_PARAMS.exp) || '';
+    const linkSig = (window.CLIENT_PARAMS && window.CLIENT_PARAMS.sig) || '';
 
     // --- Variable d'état pour stocker les réservations chargées ---
     let toutesLesReservationsClient = [];
     let toutesLesFacturesClient = [];
-    let emailClientCourant = '';
+    let emailClientCourant = linkEmail || '';
 
     /**
      * Initialise l'espace client.
@@ -75,11 +78,8 @@ document.addEventListener('DOMContentLoaded', () => {
      * Gère l'affichage initial en fonction des paramètres de l'URL.
      */
     function gererAffichageInitial() {
-        const params = new URLSearchParams(window.location.search);
-        const email = params.get('email');
-        
-        if (email) {
-            validerEtChargerClient(email);
+        if (linkEmail && linkExp && linkSig) {
+            validerEtChargerClient(linkEmail);
         } else {
             document.getElementById('conteneur-app')?.classList.add('hidden');
             document.getElementById('non-connecte')?.classList.remove('hidden');
@@ -92,6 +92,12 @@ document.addEventListener('DOMContentLoaded', () => {
      * @param {string} email L'email à valider.
      */
     function validerEtChargerClient(email) {
+        if (!linkEmail || !linkExp || !linkSig) {
+            document.getElementById('conteneur-app')?.classList.add('hidden');
+            document.getElementById('non-connecte')?.classList.remove('hidden');
+            basculerIndicateurChargement(false);
+            return;
+        }
         basculerIndicateurChargement(true);
         google.script.run
             .withSuccessHandler(reponse => {
@@ -114,7 +120,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 afficherErreurConnexion("Une erreur de communication est survenue.");
                 basculerIndicateurChargement(false);
             })
-            .validerClientParEmail(email);
+            .validerClientParEmail(email, linkExp, linkSig);
     }
 
     /**
@@ -135,7 +141,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             }
                         })
                         .withFailureHandler(err => logError(err))
-                        .calculerCAEnCoursClient(email);
+                        .calculerCAEnCoursClient(email, linkExp, linkSig);
                 } else {
                     afficherErreur(reponse.error);
                 }
@@ -145,7 +151,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 afficherErreur(err);
                 basculerIndicateurChargement(false);
             })
-            .obtenirReservationsClient(email);
+            .obtenirReservationsClient(email, linkExp, linkSig);
     }
 
     /**
@@ -162,7 +168,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             })
             .withFailureHandler(afficherErreur)
-            .obtenirFacturesPourClient(email);
+            .obtenirFacturesPourClient(email, linkExp, linkSig);
     }
 
     /**
@@ -200,7 +206,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function envoyerFactureParEmail(numero) {
-        const email = new URLSearchParams(window.location.search).get('email') || document.getElementById('email-connexion')?.value;
+        const email = linkEmail;
         if (!email) return;
         basculerIndicateurChargement(true);
         google.script.run
@@ -213,7 +219,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             })
             .withFailureHandler(afficherErreur)
-            .envoyerFactureClient(email, numero);
+            .envoyerFactureClient(email, numero, linkExp, linkSig);
     }
 
     /**
@@ -237,7 +243,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             })
             .withFailureHandler(afficherErreur)
-            .getQuestions();
+            .getQuestions(linkEmail, linkExp, linkSig);
     }
 
     function posterQuestion() {
@@ -252,7 +258,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 basculerIndicateurChargement(false);
             })
             .withFailureHandler(afficherErreur)
-            .addQuestion(texte, emailClientCourant);
+            .addQuestion(texte, emailClientCourant, linkExp, linkSig);
     }
 
     function posterReponse(questionId, reponse) {
@@ -264,7 +270,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 basculerIndicateurChargement(false);
             })
             .withFailureHandler(afficherErreur)
-            .addAnswer(questionId, reponse, emailClientCourant);
+            .addAnswer(questionId, reponse, emailClientCourant, linkExp, linkSig);
     }
 
     /**
@@ -390,7 +396,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             })
             .withFailureHandler(afficherErreur)
-            .obtenirCreneauxDisponiblesPourDate(dateString, duree, resa.eventId);
+            .obtenirCreneauxDisponiblesPourDate(dateString, duree, resa.eventId, linkEmail, linkExp, linkSig);
     }
 
     /**
@@ -405,13 +411,13 @@ document.addEventListener('DOMContentLoaded', () => {
             .withSuccessHandler(reponse => {
                 if (reponse.success) {
                     afficherNotification("Réservation mise à jour avec succès !");
-                    chargerReservationsClient(new URLSearchParams(window.location.search).get('email'));
+                    chargerReservationsClient(linkEmail);
                 } else {
                     afficherErreur(reponse.error);
                 }
             })
             .withFailureHandler(afficherErreur)
-            .mettreAJourDetailsReservation(idReservation, totalStops);
+            .mettreAJourDetailsReservation(idReservation, totalStops, linkEmail, linkExp, linkSig);
     }
 
     /**
@@ -427,13 +433,13 @@ document.addEventListener('DOMContentLoaded', () => {
             .withSuccessHandler(reponse => {
                 if (reponse.success) {
                     afficherNotification("Réservation déplacée avec succès !");
-                    chargerReservationsClient(new URLSearchParams(window.location.search).get('email'));
+                    chargerReservationsClient(linkEmail);
                 } else {
                     afficherErreur(reponse.error);
                 }
             })
             .withFailureHandler(afficherErreur)
-            .replanifierReservation(idReservation, nouvelleDate, nouvelleHeure);
+            .replanifierReservation(idReservation, nouvelleDate, nouvelleHeure, linkEmail, linkExp, linkSig);
     }
 
     function afficherErreurConnexion(message) {

--- a/Code.gs
+++ b/Code.gs
@@ -133,10 +133,11 @@ function doGet(e) {
           if (typeof CLIENT_PORTAL_ENABLED !== 'undefined' && CLIENT_PORTAL_ENABLED) {
             if (typeof CLIENT_PORTAL_SIGNED_LINKS !== 'undefined' && CLIENT_PORTAL_SIGNED_LINKS) {
               const params = (e && e.parameter) || {};
-              const emailParam = params.email || '';
+              const emailRaw = params.email || '';
+              const emailParam = String(emailRaw).trim().toLowerCase();
               const exp = params.exp || '';
               const sig = params.sig || '';
-              if (!verifySignedLink(emailParam, exp, sig)) {
+              if (!verifySignedLink(emailParam, exp, sig) || emailRaw !== emailParam) {
                 return creerReponseHtml('Lien invalide', 'Authentification requise pour accéder à l\'espace client.');
               }
             }

--- a/Configuration.gs
+++ b/Configuration.gs
@@ -93,7 +93,9 @@ const KM_ARRET_SUP = 3;
 /** @const {boolean} Active l'espace client. */
 const CLIENT_PORTAL_ENABLED = true;
 /** @const {boolean} Exige un lien signé (email+exp+sig) pour l'espace client. */
-const CLIENT_PORTAL_SIGNED_LINKS = false;
+const CLIENT_PORTAL_SIGNED_LINKS = true;
+/** @const {number} Durée de validité d'un lien client signé (heures). */
+const CLIENT_PORTAL_LINK_TTL_HOURS = 168;
 /** @const {boolean} Affiche le lien vers les informations de confidentialité. */
 const PRIVACY_LINK_ENABLED = false;
 /** @const {boolean} Sépare l'affichage des créneaux en matin et après-midi. */

--- a/Utilitaires.gs
+++ b/Utilitaires.gs
@@ -179,7 +179,8 @@ function verifySignedLink(email, expSeconds, sigBase64) {
     const exp = Number(expSeconds);
     if (!isFinite(exp)) return false;
     const nowSec = Math.floor(Date.now() / 1000);
-    if (exp < nowSec) return false; // expired
+    const ttl = (typeof CLIENT_PORTAL_LINK_TTL_HOURS !== 'undefined' ? Number(CLIENT_PORTAL_LINK_TTL_HOURS) : 24) * 3600;
+    if (exp < nowSec || exp - nowSec > ttl) return false;
     const secret = getSecret('ELS_SHARED_SECRET');
     if (!secret) return false;
     const data = `${String(email).trim().toLowerCase()}|${exp}`;
@@ -201,7 +202,8 @@ function verifySignedLink(email, expSeconds, sigBase64) {
  */
 function generateSignedClientLink(email, ttlSeconds) {
   if (!email) throw new Error('Email requis');
-  const exp = Math.floor(Date.now() / 1000) + (Number(ttlSeconds) > 0 ? Number(ttlSeconds) : 86400);
+  const ttl = (Number(ttlSeconds) > 0 ? Number(ttlSeconds) : (typeof CLIENT_PORTAL_LINK_TTL_HOURS !== 'undefined' ? Number(CLIENT_PORTAL_LINK_TTL_HOURS) : 24) * 3600);
+  const exp = Math.floor(Date.now() / 1000) + ttl;
   const secret = getSecret('ELS_SHARED_SECRET');
   if (!secret) throw new Error('Secret manquant: ELS_SHARED_SECRET');
   const data = `${String(email).trim().toLowerCase()}|${exp}`;


### PR DESCRIPTION
## Summary
- enable signed client portal links with configurable TTL
- validate signed link and match email on client portal access
- propagate signed link params through client portal requests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdbe33810c83269083e0b9a980b344