### PR TITLE
feat: log resident invoice results

### DIFF
--- a/Configuration.gs
+++ b/Configuration.gs
@@ -143,6 +143,8 @@ const PRO_QA_ENABLED = false;
 const DEBUG_MENU_ENABLED = true;
 /** @const {boolean} Sert une version de démo de la page de réservation. */
 const DEMO_RESERVATION_ENABLED = false;
+/** @const {boolean} Active l'écriture des logs de facturation. */
+const BILLING_LOG_ENABLED = false;
 /** @const {boolean} Active le mode test pour la facturation V2 (aucune écriture). */
 const BILLING_V2_DRYRUN = false;
 /** @const {boolean} Active la journalisation détaillée des requêtes web. */
@@ -186,6 +188,7 @@ const FLAGS = Object.freeze({
   debugMenuEnabled: DEBUG_MENU_ENABLED,
   demoReservationEnabled: DEMO_RESERVATION_ENABLED,
   billingV2Dryrun: BILLING_V2_DRYRUN,
+  billingLogEnabled: BILLING_LOG_ENABLED,
   requestLoggingEnabled: REQUEST_LOGGING_ENABLED,
   postEndpointEnabled: POST_ENDPOINT_ENABLED,
   clientPortalAttemptLimitEnabled: CLIENT_PORTAL_ATTEMPT_LIMIT_ENABLED,
@@ -277,6 +280,7 @@ const CONFIG = Object.freeze({
   BILLING_MODAL_ENABLED,
   RESIDENT_BILLING_ENABLED,
   RESERVATION_VERIFY_ENABLED,
+  BILLING_LOG_ENABLED,
   BILLING_V2_DRYRUN
 });
 

--- a/FacturationResident.gs
+++ b/FacturationResident.gs
@@ -163,12 +163,21 @@ function creerEtEnvoyerFactureResident(res) {
   var pdfFile = DriveApp.getFolderById(BILLING.FACTURES_FOLDER_ID).createFile(pdf).setName(num + '.pdf');
   DriveApp.getFileById(tmpl.getId()).setTrashed(true);
 
+  var status;
   if (res.RESIDENT_EMAIL) {
     GmailApp.sendEmail(res.RESIDENT_EMAIL, '[' + BILLING.INVOICE_PREFIX + '] Votre facture ' + num,
       'Bonjour,\n\nVeuillez trouver votre facture en pièce jointe.\nMontant TTC: ' + ttc.toFixed(2) + ' €.\n' + (BILLING.TVA_APPLICABLE ? '' : BILLING.TVA_MENTION) + '\n\nMerci,',
       { attachments: [pdfFile.getBlob()] }
     );
+    status = 'ENVOYEE';
+  } else {
+    status = 'EMAIL_MANQUANT';
   }
 
-  // TODO: écrire retour dans la feuille (FACTURE_NUM, FACTURE_URL, STATUT)
+  if (BILLING_LOG_ENABLED) {
+    var sheet = SpreadsheetApp.getActive().getSheetByName(SHEET_FACTURATION);
+    if (sheet) {
+      sheet.appendRow([num, pdfFile.getUrl(), status]);
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add BILLING_LOG_ENABLED flag to toggle invoice logging
- append invoice number, URL and status to Facturation sheet after sending email

## Testing
- `npm test`
- `npm run test:clasp` *(fails: unknown option '--noninteractive')*
- `node <manual verification script>`

------
https://chatgpt.com/codex/tasks/task_e_68bdc63cbd88832692761fa505f11a62