### PR TITLE
feat: add ARIA roles to calendar grid

### DIFF
--- a/Reservation_Interface.html
+++ b/Reservation_Interface.html
@@ -177,7 +177,7 @@
         <div class="calendrier-jours-semaine" aria-hidden="true">
           <div>Lun</div><div>Mar</div><div>Mer</div><div>Jeu</div><div>Ven</div><div>Sam</div><div>Dim</div>
         </div>
-        <div id="grille-calendrier" class="grille-calendrier"></div>
+        <div id="grille-calendrier" class="grille-calendrier" role="grid"></div>
       </div>
 
       <div id="colonne-droite">

--- a/Reservation_JS_Calendrier.html
+++ b/Reservation_JS_Calendrier.html
@@ -36,11 +36,14 @@ function afficherCalendrier(mois, annee) {
 
         // Cases vides d'offset (lundi=1 -> 0 offset, dimanche=0 -> 6)
         for (let i = 0; i < (premierJour === 0 ? 6 : premierJour - 1); i++) {
-          grilleCalendrier.appendChild(document.createElement('div'));
+          const celluleVide = document.createElement('div');
+          celluleVide.setAttribute('role', 'gridcell');
+          grilleCalendrier.appendChild(celluleVide);
         }
 
         for (let jour = 1; jour <= joursDansLeMois; jour++) {
           const cellule = document.createElement('div');
+          cellule.setAttribute('role', 'gridcell');
           const date = new Date(annee, mois - 1, jour);
           const y = annee;
           const m = String(mois).padStart(2, '0');


### PR DESCRIPTION
## Summary
- mark calendar grid container with `role="grid"`
- mark generated calendar cells with `role="gridcell"` for better screen reader support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdc6422d2c83269869e0a2f72efc3a