### PR TITLE
feat: gradient calendar load bar with optional opacity

### DIFF
--- a/Configuration.gs
+++ b/Configuration.gs
@@ -115,6 +115,9 @@ const CALENDAR_RESYNC_ENABLED = true;
 /** @const {boolean} Supprime les identifiants d'événements introuvables pour garder la base propre. */
 const CALENDAR_PURGE_ENABLED = true;
 
+/** @const {boolean} Module l'opacité de la barre de disponibilité selon le taux de charge. */
+const CALENDAR_BAR_OPACITY_ENABLED = false;
+
 /** @const {boolean} Vérifie la création d'événement et l'unicité des ID de réservation. */
 const RESERVATION_VERIFY_ENABLED = false;
 
@@ -179,6 +182,7 @@ const FLAGS = Object.freeze({
   caEnCoursEnabled: CA_EN_COURS_ENABLED,
   calendarResyncEnabled: CALENDAR_RESYNC_ENABLED,
   calendarPurgeEnabled: CALENDAR_PURGE_ENABLED,
+  calendarBarOpacityEnabled: CALENDAR_BAR_OPACITY_ENABLED,
   reservationUiV2Enabled: RESERVATION_UI_V2_ENABLED,
   residentBillingEnabled: RESIDENT_BILLING_ENABLED,
   billingModalEnabled: BILLING_MODAL_ENABLED,

--- a/Reservation_CSS.html
+++ b/Reservation_CSS.html
@@ -144,7 +144,7 @@ body {
 .jour-calendrier:not(.desactive):hover { background-color: var(--violet); border-color: var(--violet); }
 .jour-calendrier.desactive { color: var(--muted); cursor: not-allowed; background-color: var(--bg); }
 .barre-disponibilite { height: 4px; background-color: var(--muted); border-radius: var(--radius); margin: 5px auto 0; overflow: hidden; max-width: 80%; }
-.barre-disponibilite div { height: 100%; background-color: var(--bleu-clair); }
+.barre-disponibilite div { height: 100%; background: linear-gradient(90deg,#8e44ad,#3498db); }
 
 /* --- PANIER --- */
 #liste-panier { list-style: none; padding: 0; margin: 0; }

--- a/Reservation_JS_Calendrier.html
+++ b/Reservation_JS_Calendrier.html
@@ -67,6 +67,10 @@ function afficherCalendrier(mois, annee) {
             const rempl = document.createElement('div');
             const ratio = (dispo.total > 0) ? (dispo.disponibles / dispo.total) : 0;
             rempl.style.width = `${Math.min(100, Math.max(0, ratio * 100))}%`;
+            if (window.etat?.flags?.calendarBarOpacityEnabled) {
+              const charge = 1 - ratio;
+              rempl.style.opacity = Math.min(1, Math.max(0, charge));
+            }
             barre.appendChild(rempl);
             cellule.appendChild(barre);
           }

--- a/Reservation_JS_Principal.html
+++ b/Reservation_JS_Principal.html
@@ -23,6 +23,7 @@ function initializeFlags(flags = {}) {
     caEnCoursEnabled: false,
     calendarResyncEnabled: false,
     calendarPurgeEnabled: false,
+    calendarBarOpacityEnabled: false,
     reservationUiV2Enabled: false,
     residentBillingEnabled: false,
     billingModalEnabled: false,


### PR DESCRIPTION
## Summary
- replace availability bar color with brand gradient
- add optional opacity modulation driven by `CALENDAR_BAR_OPACITY_ENABLED`

## Testing
- `npm test`
- `npm run test:clasp` *(fails: unknown option '--noninteractive')*


------
https://chatgpt.com/codex/tasks/task_e_68bdc64833dc832689242c79dec58b31