### PR TITLE
chore: remove node_modules [no-structure-change]

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@
 ## Contributing
 See `AGENTS.md` for project structure, coding style, testing steps, and the pull request process.
 
+## Installation locale
+
+Installez les dépendances Node locales :
+
+```bash
+npm install
+```
+
 ## Useful Tools
 - `./clasp-helper.cmd`: Launches a small GUI to Push/Pull/Version/Deploy and manage snapshots.
 - Scripts overview: see `scripts/README.md` for `open-projet*.cmd` launchers.


### PR DESCRIPTION
## Summary
- confirm `.gitignore` ignores `node_modules`
- document `npm install` for local setup

## Testing
- `npm install`
- `npm test`
- `npm run test:clasp` *(fails: unknown option '--noninteractive')*


------
https://chatgpt.com/codex/tasks/task_e_68bdc6532c90832686804f22c15aee03