### PR TITLE
chore: add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 EL Services
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -122,3 +122,6 @@ Open the Apps Script editor, go to **File → Project properties → Script prop
 - Code de la santé publique – art. R.5125-47 à R.5125-52
 - Ordre des pharmaciens – livraison et dispensation
 - OMéDIT – Transport en EHPAD
+
+## License
+Ce projet est distribué sous la licence MIT. Consultez le fichier `LICENSE` pour plus d'informations.


### PR DESCRIPTION
## Summary
- add MIT license file
- reference license in README

## Testing
- `npm test`
- `npm run test:clasp` *(fails: unknown option '--noninteractive')*


------
https://chatgpt.com/codex/tasks/task_e_68bdc659088c8326a4a4aed5660482b5