### PR TITLE
fix: inline hero icon to prevent 404

### DIFF
--- a/Reservation_Interface.html
+++ b/Reservation_Interface.html
@@ -118,7 +118,9 @@
 
     <section id="hero-tarifs" class="hero-tarifs">
       <div class="hero-titre">
-        <img src="icone-gelule.svg" class="hero-icone" role="img" aria-label="Gélule de pharmacie" alt="">
+        <div class="hero-icone">
+          <?!= include('icone-gelule.svg'); ?>
+        </div>
         <h1>Gagnez du temps au comptoir : la tournée pharmacie pensée pour pharmaciens, préparateurs, infirmiers</h1>
       </div>
       <p class="hero-sous-titre">Fiabilité éprouvée, sacs scellés sécurisés et respect du patient garanti.</p>


### PR DESCRIPTION
## Summary
- inline hero capsule icon via include to avoid network fetch

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdcfacb1588326812d5deb65d8d607