### PR TITLE
feat: add pharmacy SVG icons

### DIFF
--- a/Reservation_CSS.html
+++ b/Reservation_CSS.html
@@ -85,6 +85,11 @@ body {
   margin-top: 0;
   color: var(--violet);
 }
+.tarif-icone {
+  width: 48px;
+  height: 48px;
+  margin: 0 auto 0.5rem;
+}
 .tarif-carte ul {
   list-style: none;
   padding: 0;

--- a/Reservation_Interface.html
+++ b/Reservation_Interface.html
@@ -126,6 +126,9 @@
       <p class="hero-sous-titre">Fiabilité éprouvée, sacs scellés sécurisés et respect du patient garanti.</p>
       <div class="tarifs-cartes">
         <div class="tarif-carte">
+          <div class="tarif-icone">
+            <?!= include('icone-pilulier.svg'); ?>
+          </div>
           <h3>Course de base</h3>
           <ul>
             <li><?= TARIFS.Normal.base ?> € TTC</li>
@@ -135,6 +138,9 @@
           <a href="#vue-calendrier" class="btn btn-primaire">Réserver</a>
         </div>
         <div class="tarif-carte">
+          <div class="tarif-icone">
+            <?!= include('icone-flacon.svg'); ?>
+          </div>
           <h3>Arrêts supplémentaires</h3>
           <ul>
             <? for (var i = 0; i < TARIFS.Normal.arrets.length; i++) {
@@ -144,6 +150,9 @@
           </ul>
         </div>
         <div class="tarif-carte">
+          <div class="tarif-icone">
+            <?!= include('icone-tampon.svg'); ?>
+          </div>
           <h3>Options</h3>
           <ul>
             <li>Urgent : +<?= TARIFS.Urgent.base ?> € TTC</li>

--- a/icone-flacon.svg
+++ b/icone-flacon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" role="img" aria-label="Flacon de médicament">
+  <defs>
+    <linearGradient id="flaconGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#8e44ad" />
+      <stop offset="100%" stop-color="#3498db" />
+    </linearGradient>
+  </defs>
+  <rect x="16" y="6" width="16" height="6" fill="#5dade2" />
+  <rect x="12" y="12" width="24" height="30" rx="4" fill="url(#flaconGradient)" />
+  <rect x="18" y="20" width="12" height="6" fill="#ffffff" opacity="0.5" />
+</svg>

--- a/icone-pilulier.svg
+++ b/icone-pilulier.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" role="img" aria-label="Pilulier pharmaceutique">
+  <defs>
+    <linearGradient id="pilulierGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#8e44ad" />
+      <stop offset="100%" stop-color="#3498db" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="12" width="40" height="24" rx="4" fill="url(#pilulierGradient)" />
+  <line x1="12" y1="12" x2="12" y2="36" stroke="#5dade2" stroke-width="2" />
+  <line x1="24" y1="12" x2="24" y2="36" stroke="#5dade2" stroke-width="2" />
+  <line x1="36" y1="12" x2="36" y2="36" stroke="#5dade2" stroke-width="2" />
+</svg>

--- a/icone-tampon.svg
+++ b/icone-tampon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" role="img" aria-label="Tampon officinal">
+  <defs>
+    <linearGradient id="tamponGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#8e44ad" />
+      <stop offset="100%" stop-color="#3498db" />
+    </linearGradient>
+  </defs>
+  <circle cx="24" cy="14" r="6" fill="url(#tamponGradient)" />
+  <rect x="16" y="20" width="16" height="8" rx="2" fill="#5dade2" />
+  <rect x="8" y="30" width="32" height="8" rx="2" fill="url(#tamponGradient)" />
+</svg>


### PR DESCRIPTION
## Summary
- add pilulier, flacon and tampon SVG icons with gradient and ARIA labels
- display new icons in tariff cards
- style tariff icons for consistent size

## Testing
- `npm test`
- `npm run test:clasp` *(fails: unknown option --noninteractive)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd963326c8326aec356183dbf6cf5