### PR TITLE
feat: add SVG sprite for icons

### DIFF
--- a/README_icons.md
+++ b/README_icons.md
@@ -2,14 +2,22 @@
 
 Cette page documente les pictogrammes utilisés dans l'application et leurs emplacements.
 
-| Fichier | aria-label | Usage |
+Les icônes sont regroupées dans `icons.svg`. Pour les insérer :
+
+```html
+<svg width="48" height="48" role="img" aria-label="Gélule de pharmacie">
+  <use href="#icone-gelule"></use>
+</svg>
+```
+
+| Référence | aria-label | Usage |
 | --- | --- | --- |
-| icone-gelule.svg | Gélule | Icône principale dans le héros |
-| icone-pilulier.svg | Pilulier | Carte "Course de base" |
-| icone-flacon.svg | Flacon de médicament | Carte "Arrêts supplémentaires" |
-| icone-tampon.svg | Tampon | Carte "Options" |
-| icone-semainier.svg | Semainier | Icônes supplémentaires du héros |
-| icone-boite-scellee.svg | Boîte scellée | Icônes supplémentaires du héros |
-| icone-livraison.svg | Livraison à domicile | Icônes supplémentaires du héros |
+| #icone-gelule | Gélule de pharmacie | Icône principale dans le héros |
+| #icone-pilulier | Pilulier pharmaceutique | Carte "Course de base" |
+| #icone-flacon | Flacon de médicament | Carte "Arrêts supplémentaires" |
+| #icone-tampon | Tampon officinal | Carte "Options" |
+| #icone-semainier | Semainier | Icônes supplémentaires du héros |
+| #icone-boite-scellee | Boîte scellée | Icônes supplémentaires du héros |
+| #icone-livraison | Livraison à domicile | Icônes supplémentaires du héros |
 
 Les preuves de licence commerciale de chaque visuel sont archivées dans le dossier `licences/`.

--- a/Reservation_Interface.html
+++ b/Reservation_Interface.html
@@ -71,6 +71,9 @@
   <?!= include('charte'); ?>
 </head>
 <body>
+  <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+    <?!= include('icons.svg'); ?>
+  </svg>
 
   <script type="application/json" id="conf-tarifs"><?!= TARIFS_JSON ?></script>
   <script>
@@ -119,28 +122,38 @@
     <section id="hero-tarifs" class="hero-tarifs">
       <div class="hero-titre">
         <div class="hero-icone">
-          <?!= include('icone-gelule.svg'); ?>
+          <svg width="48" height="48" role="img" aria-label="Gélule de pharmacie" focusable="false">
+            <use href="#icone-gelule"></use>
+          </svg>
         </div>
         <h1>Gagnez du temps au comptoir : la tournée pharmacie pensée pour pharmaciens, préparateurs, infirmiers</h1>
       </div>
       <p class="hero-sous-titre">Fiabilité éprouvée, sacs scellés sécurisés et respect du patient garanti.</p>
       <? if (EXTRA_ICONS_ENABLED) { ?>
-      <div class="hero-icones">
-        <div class="hero-icone">
-          <?!= include('icone-semainier.svg'); ?>
+        <div class="hero-icones">
+          <div class="hero-icone">
+            <svg width="48" height="48" role="img" aria-label="Semainier" focusable="false">
+              <use href="#icone-semainier"></use>
+            </svg>
+          </div>
+          <div class="hero-icone">
+            <svg width="48" height="48" role="img" aria-label="Boîte scellée" focusable="false">
+              <use href="#icone-boite-scellee"></use>
+            </svg>
+          </div>
+          <div class="hero-icone">
+            <svg width="48" height="48" role="img" aria-label="Livraison à domicile" focusable="false">
+              <use href="#icone-livraison"></use>
+            </svg>
+          </div>
         </div>
-        <div class="hero-icone">
-          <?!= include('icone-boite-scellee.svg'); ?>
-        </div>
-        <div class="hero-icone">
-          <?!= include('icone-livraison.svg'); ?>
-        </div>
-      </div>
       <? } ?>
       <div class="tarifs-cartes">
         <div class="tarif-carte">
           <div class="tarif-icone">
-            <?!= include('icone-pilulier.svg'); ?>
+            <svg width="48" height="48" role="img" aria-label="Pilulier pharmaceutique" focusable="false">
+              <use href="#icone-pilulier"></use>
+            </svg>
           </div>
           <h3>Course de base</h3>
           <ul>
@@ -152,7 +165,9 @@
         </div>
         <div class="tarif-carte">
           <div class="tarif-icone">
-            <?!= include('icone-flacon.svg'); ?>
+            <svg width="48" height="48" role="img" aria-label="Flacon de médicament" focusable="false">
+              <use href="#icone-flacon"></use>
+            </svg>
           </div>
           <h3>Arrêts supplémentaires</h3>
           <ul>
@@ -164,7 +179,9 @@
         </div>
         <div class="tarif-carte">
           <div class="tarif-icone">
-            <?!= include('icone-tampon.svg'); ?>
+            <svg width="48" height="48" role="img" aria-label="Tampon officinal" focusable="false">
+              <use href="#icone-tampon"></use>
+            </svg>
           </div>
           <h3>Options</h3>
           <ul>

--- a/icons.svg
+++ b/icons.svg
@@ -1,0 +1,86 @@
+<symbol id="icone-boite-scellee" viewBox="0 0 48 48">
+  <defs>
+    <linearGradient id="boiteGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#8e44ad" />
+      <stop offset="100%" stop-color="#3498db" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="14" width="36" height="24" rx="2" fill="url(#boiteGradient)" />
+  <rect x="6" y="14" width="36" height="6" fill="#5dade2" />
+  <rect x="18" y="22" width="12" height="16" fill="#ffffff" opacity="0.3" />
+</symbol>
+<symbol id="icone-flacon" viewBox="0 0 48 48">
+  <defs>
+    <linearGradient id="flaconGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#8e44ad" />
+      <stop offset="100%" stop-color="#3498db" />
+    </linearGradient>
+  </defs>
+  <rect x="16" y="6" width="16" height="6" fill="#5dade2" />
+  <rect x="12" y="12" width="24" height="30" rx="4" fill="url(#flaconGradient)" />
+  <rect x="18" y="20" width="12" height="6" fill="#ffffff" opacity="0.5" />
+</symbol>
+<symbol id="icone-gelule" viewBox="0 0 48 48">
+  <defs>
+    <linearGradient id="geluleGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#8e44ad" />
+      <stop offset="100%" stop-color="#3498db" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="12" width="40" height="24" rx="12" fill="url(#geluleGradient)" />
+  <line x1="24" y1="12" x2="24" y2="36" stroke="#ffffff" stroke-width="2" />
+</symbol>
+<symbol id="icone-livraison" viewBox="0 0 48 48">
+  <defs>
+    <linearGradient id="livraisonGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#8e44ad" />
+      <stop offset="100%" stop-color="#3498db" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="18" width="28" height="14" rx="2" fill="url(#livraisonGradient)" />
+  <rect x="32" y="22" width="12" height="10" rx="2" fill="url(#livraisonGradient)" />
+  <rect x="34" y="24" width="6" height="4" fill="#5dade2" />
+  <circle cx="14" cy="34" r="4" fill="#5dade2" />
+  <circle cx="34" cy="34" r="4" fill="#5dade2" />
+</symbol>
+<symbol id="icone-pilulier" viewBox="0 0 48 48">
+  <defs>
+    <linearGradient id="pilulierGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#8e44ad" />
+      <stop offset="100%" stop-color="#3498db" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="12" width="40" height="24" rx="4" fill="url(#pilulierGradient)" />
+  <line x1="12" y1="12" x2="12" y2="36" stroke="#5dade2" stroke-width="2" />
+  <line x1="24" y1="12" x2="24" y2="36" stroke="#5dade2" stroke-width="2" />
+  <line x1="36" y1="12" x2="36" y2="36" stroke="#5dade2" stroke-width="2" />
+</symbol>
+<symbol id="icone-semainier" viewBox="0 0 48 48">
+  <defs>
+    <linearGradient id="semainierGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#8e44ad" />
+      <stop offset="100%" stop-color="#3498db" />
+    </linearGradient>
+  </defs>
+  <rect x="2" y="14" width="44" height="20" rx="4" fill="url(#semainierGradient)" />
+  <rect x="2" y="10" width="44" height="6" fill="#5dade2" />
+  <g stroke="#ffffff" stroke-width="1" opacity="0.5">
+    <line x1="8" y1="14" x2="8" y2="34" />
+    <line x1="14" y1="14" x2="14" y2="34" />
+    <line x1="20" y1="14" x2="20" y2="34" />
+    <line x1="26" y1="14" x2="26" y2="34" />
+    <line x1="32" y1="14" x2="32" y2="34" />
+    <line x1="38" y1="14" x2="38" y2="34" />
+  </g>
+</symbol>
+<symbol id="icone-tampon" viewBox="0 0 48 48">
+  <defs>
+    <linearGradient id="tamponGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#8e44ad" />
+      <stop offset="100%" stop-color="#3498db" />
+    </linearGradient>
+  </defs>
+  <circle cx="24" cy="14" r="6" fill="url(#tamponGradient)" />
+  <rect x="16" y="20" width="16" height="8" rx="2" fill="#5dade2" />
+  <rect x="8" y="30" width="32" height="8" rx="2" fill="url(#tamponGradient)" />
+</symbol>


### PR DESCRIPTION
## Summary
- consolidate pharmacy icons into `icons.svg` sprite
- use `<svg><use></use></svg>` references in `Reservation_Interface.html`
- document sprite usage in `README_icons.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be892b99b08326945a2723f23b7c54