### PR TITLE
feat: ajoute flag thème capsule

### DIFF
--- a/Admin_Interface.html
+++ b/Admin_Interface.html
@@ -67,8 +67,10 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <?!= include('ThemeCapsule') ?>
-  <style id="theme-style"></style>
+  <? if (THEME_CAPSULE_ENABLED) { ?>
+    <?!= include('ThemeCapsule') ?>
+    <style id="theme-style"></style>
+  <? } ?>
   <?!= include('Admin_CSS'); ?>
   <?!= include('charte'); ?>
 </head>

--- a/Client_Espace.html
+++ b/Client_Espace.html
@@ -66,8 +66,10 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <?!= include('ThemeCapsule') ?>
-  <style id="theme-style"></style>
+  <? if (THEME_CAPSULE_ENABLED) { ?>
+    <?!= include('ThemeCapsule') ?>
+    <style id="theme-style"></style>
+  <? } ?>
   <?!= include('Client_CSS'); ?>
   <?!= include('charte'); ?>
 </head>

--- a/Configuration.gs
+++ b/Configuration.gs
@@ -170,6 +170,8 @@ const RESERVATION_CACHE_ENABLED = true;
 const THEME_V2_ENABLED = false;
 /** @const {boolean} Active le thème graphique V3 (header sticky, capsules). */
 const THEME_V3_ENABLED = true;
+/** @const {boolean} Active la capsule de thème (styles capsules). */
+const THEME_CAPSULE_ENABLED = false;
 /** @const {boolean} Permet aux clients de choisir leur thème visuel. */
 // const THEME_SELECTION_ENABLED = false; // supprimé: sélection de thème désactivée
 /** @const {string} Thème appliqué par défaut lorsque la sélection est active. */
@@ -207,6 +209,7 @@ const FLAGS = Object.freeze({
   extraIconsEnabled: EXTRA_ICONS_ENABLED,
   themeV2Enabled: THEME_V2_ENABLED,
   themeV3Enabled: THEME_V3_ENABLED,
+  themeCapsuleEnabled: THEME_CAPSULE_ENABLED,
   pricingRulesV2Enabled: PRICING_RULES_V2_ENABLED,
   returnImpactsEstimatesEnabled: RETURN_IMPACTS_ESTIMATES_ENABLED
 });

--- a/README.md
+++ b/README.md
@@ -59,9 +59,10 @@ Le projet utilise `@google/clasp` version `2.5.0` en local comme en CI.
 3. En cas de conflit, exécuter `npx @google/clasp pull` avant de retenter.
 
 ## Sélecteur de thème
-1. Activer `THEME_SELECTION_ENABLED` dans `Configuration.gs` (désactivé par défaut).
-2. `clasp push -f` puis créer une nouvelle version pour déploiement.
-3. Pour rollback, remettre le flag à `false` et redéployer la version précédente.
+1. Activer `THEME_CAPSULE_ENABLED` dans `Configuration.gs` (désactivé par défaut).
+2. Optionnel : activer `THEME_SELECTION_ENABLED` pour laisser l'utilisateur choisir.
+3. `clasp push -f` puis créer une nouvelle version pour déploiement.
+4. Pour rollback, remettre les flags à `false` et redéployer la version précédente.
 
 ## Menu Debug
 1. Activer `DEBUG_MENU_ENABLED` dans `Configuration.gs`.

--- a/Reservation_Interface.html
+++ b/Reservation_Interface.html
@@ -65,8 +65,10 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <?!= include('ThemeCapsule') ?>
-  <style id="theme-style"></style>
+  <? if (THEME_CAPSULE_ENABLED) { ?>
+    <?!= include('ThemeCapsule') ?>
+    <style id="theme-style"></style>
+  <? } ?>
   <?!= include('Reservation_CSS'); ?>
   <?!= include('charte'); ?>
 </head>


### PR DESCRIPTION
## Summary
- add `THEME_CAPSULE_ENABLED` flag in configuration
- guard ThemeCapsule includes in Admin/Client/Reservation interfaces
- document theme capsule flag in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be9182deb083268f37e7cb01d19111