### PR TITLE
branding: magenta urgent tone

### DIFF
--- a/Reservation_CSS.html
+++ b/Reservation_CSS.html
@@ -248,7 +248,7 @@ body {
 }
 
 
-/* Créneau urgent - Utilise la couleur d'erreur (rouge) */
+/* Créneau urgent - Utilise la couleur d'erreur (magenta) */
 .slot-btn.urgent {
   color: var(--danger);
 }

--- a/ThemeCapsule.html
+++ b/ThemeCapsule.html
@@ -15,7 +15,7 @@
   --couleur-primaire: var(--violet);
   --couleur-secondaire: var(--bleu);
   --couleur-succes: var(--bleu-clair);
-  --danger: #2f80c2;
+  --danger: #ff006e;
   --couleur-erreur: var(--danger);
   --gris-clair: #f9f9f9;
   --gris-moyen: #6c757d;

--- a/charte.html
+++ b/charte.html
@@ -10,7 +10,7 @@
   --bleu: var(--blue);
   --bleu-clair: var(--light);
   --txt: var(--text);
-  --danger: #c0392b;
+  --danger: #ff006e;
 }
 *{box-sizing:border-box} html,body{height:100%}
 body{margin:0;font-family:var(--font);color:var(--text);background:linear-gradient(120deg,var(--bg),#fff 60%)}


### PR DESCRIPTION
## Summary
- replace legacy urgent color with magenta tone via `--danger`
- sync design guide and reservation comment to new color

## Testing
- `npm test`
- `python - <<'PY' ...` contrast = 5.04


------
https://chatgpt.com/codex/tasks/task_e_68be91944af083269577b01597b390c3