### PR TITLE
branding: preload Montserrat font [no-structure-change]

### DIFF
--- a/Admin_Interface.html
+++ b/Admin_Interface.html
@@ -64,9 +64,10 @@
   </script>
   <title><?= nomService ?> | Tableau de Bord Administrateur</title>
 
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap" media="print" onload="this.media='all'">
   <?!= include('ThemeCapsule') ?>
   <style id="theme-style"></style>
   <?!= include('Admin_CSS'); ?>

--- a/CGV.html
+++ b/CGV.html
@@ -61,9 +61,10 @@
   }
   </script>
   <title><?= nomService ?> | CGV</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap" media="print" onload="this.media='all'">
   <style><?!= include('Styles'); ?></style>
   <?!= include('charte'); ?>
 </head>

--- a/Client_Espace.html
+++ b/Client_Espace.html
@@ -63,9 +63,10 @@
   </script>
   <title><?= nomService ?> | Mon Espace Client</title>
 
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap" media="print" onload="this.media='all'">
   <?!= include('ThemeCapsule') ?>
   <style id="theme-style"></style>
   <?!= include('Client_CSS'); ?>

--- a/Code.gs
+++ b/Code.gs
@@ -75,7 +75,7 @@ function menuGenererLienClient() {
     const hours = parseInt(hoursResp.getResponseText() || '168', 10);
     const res = genererLienEspaceClient(email, isNaN(hours) ? 168 : hours);
     const html = HtmlService.createHtmlOutput(
-      `<div style="font-family:Montserrat,sans-serif;line-height:1.5">
+        `<div style="font-family:'Montserrat',system-ui,sans-serif;line-height:1.5">
          <h3>Lien Espace Client</h3>
          <p>Ce lien expire à: ${new Date(res.exp*1000).toLocaleString()}</p>
          <input id="l" type="text" value="${res.url.replace(/&/g,'&amp;').replace(/</g,'&lt;')}" style="width:100%" readonly />

--- a/Debug_Interface.html
+++ b/Debug_Interface.html
@@ -62,11 +62,12 @@
   }
   </script>
   <title><?= nomService ?> | Panneau de Débogage</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <style>
-        body { font-family: Montserrat, sans-serif; margin: 20px; background-color: #0b0e13; color: #fff; }
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap" media="print" onload="this.media='all'">
+    <style>
+          body { font-family: 'Montserrat', system-ui, sans-serif; margin: 20px; background-color: #0b0e13; color: #fff; }
         h1 { color: #fff; }
         .test-suite { background-color: #0f151f; border: 1px solid #1d2a3a; border-radius: 5px; padding: 15px; margin-bottom: 15px; }
         button { background: linear-gradient(135deg, #8e44ad, #3498db); color: #fff; border: none; padding: 10px 18px; border-radius: 9999px; cursor: pointer; margin-right: 10px; box-shadow: 0 6px 18px rgba(0,0,0,.18); transition: transform .08s ease, box-shadow .2s ease; }

--- a/Infos_confidentialite.html
+++ b/Infos_confidentialite.html
@@ -61,9 +61,10 @@
   }
   </script>
   <title><?= nomService ?> | Infos & confidentialité</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap" media="print" onload="this.media='all'">
   <style><?!= include('Styles'); ?></style>
   <?!= include('charte'); ?>
 </head>

--- a/Logo.html
+++ b/Logo.html
@@ -25,7 +25,7 @@ Description: Ce fichier contient le code SVG du logo de l'entreprise.
     </defs>
     <path d="M 60 40 C 40 40, 40 70, 60 70 M 60 55 L 30 55 M 60 70 C 80 70, 90 60, 85 45 Q 95 55 105 50" stroke="url(#airyGradient)" stroke-width="4" stroke-linecap="round" fill="none"/>
     <g text-anchor="start">
-        <text x="120" y="62" font-family="Montserrat, sans-serif" font-size="28" font-weight="700" fill="#212529">ELS</text>
+        <text x="120" y="62" font-family="Montserrat, system-ui, sans-serif" font-size="28" font-weight="700" fill="#212529">ELS</text>
     </g>
   </svg>
 </div>

--- a/Maintenance.gs
+++ b/Maintenance.gs
@@ -168,7 +168,7 @@ function menuVerifierStructureFeuilles() {
   try {
     const res = verifierStructureFeuilles();
     const lignes = res.report.map(r => `- ${r.sheet} : ${r.created ? 'créée' : 'ok'}${r.missingHeaders && r.missingHeaders.length ? ' | entêtes ajoutés: ' + r.missingHeaders.join(', ') : ''}`);
-    const html = `<div style="font-family:Montserrat,sans-serif;line-height:1.5">
+      const html = `<div style="font-family:'Montserrat',system-ui,sans-serif;line-height:1.5">
       <h2>Vérification structure des feuilles</h2>
       <p>Résultat: ${res.success ? 'Succès' : 'Erreur'}</p>
       <pre style="white-space:pre-wrap">${lignes.join('\n')}</pre>

--- a/Reservation.gs
+++ b/Reservation.gs
@@ -134,7 +134,7 @@ function envoyerDevisParEmail(donneesDevis) {
 
     const sujet = `Votre devis de réservation - ${NOM_ENTREPRISE}`;
     const corpsHtml = `
-      <div style="font-family: Montserrat, sans-serif; color: #333;">
+        <div style="font-family: 'Montserrat', system-ui, sans-serif; color: #333;">
         <h2>Devis pour vos réservations de tournées</h2>
         <p>Bonjour ${client.nom || ''},</p>
         <p>Voici le détail du devis pour les tournées actuellement dans votre panier. Ce devis est valable 24 heures, sous réserve de disponibilité des créneaux.</p>

--- a/Reservation_Interface.html
+++ b/Reservation_Interface.html
@@ -62,9 +62,10 @@
   }
   </script>
   <title><?= nomService ?> | Réservation de Livraison</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap" media="print" onload="this.media='all'">
   <?!= include('ThemeCapsule') ?>
   <style id="theme-style"></style>
   <?!= include('Reservation_CSS'); ?>

--- a/ThemeCapsule.html
+++ b/ThemeCapsule.html
@@ -1,6 +1,6 @@
 <style>
 :root {
-  --font: 'Montserrat', sans-serif;
+  --font: 'Montserrat', system-ui, sans-serif;
   --violet: #8e44ad;
   --bleu: #3498db;
   --bleu-clair: #5dade2;

--- a/charte.html
+++ b/charte.html
@@ -1,6 +1,6 @@
 <style>
 :root{
-  --font:'Montserrat', sans-serif;
+  --font:'Montserrat', system-ui, sans-serif;
   --violet:#8e44ad; --blue:#3498db; --light:#5dade2;
   --bg:#f7f9fc; --card:#fff; --text:#0f172a; --muted:#64748b; --border:#e5e7eb;
   --radius:16px; --shadow:0 6px 22px rgba(16,24,40,.08); --focus:2px solid #1f6feb;


### PR DESCRIPTION
## Summary
- optimize Montserrat loading by preloading and deferring stylesheet in all interfaces
- add system-ui fallback for fonts across styles and templates

## Testing
- `npm test`
- `npm run test:clasp` *(fails: unknown option '--noninteractive')*

------
https://chatgpt.com/codex/tasks/task_e_68be918a220483269db8a36fac342af2