### PR TITLE
feat: add weekly quarter-hour slot helper

### DIFF
--- a/Calendrier.gs
+++ b/Calendrier.gs
@@ -5,6 +5,16 @@
 //              données de Google Calendar et les blocages manuels.
 // =================================================================
 
+function getQuarterHourSlotsForWeek_(mondayDate) {
+  const start = new Date(mondayDate); start.setHours(0, 0, 0, 0);
+  const end = new Date(start); end.setDate(end.getDate() + 7);
+  const slots = [];
+  for (var t = new Date(start); t < end; t = new Date(t.getTime() + 15 * 60000)) {
+    slots.push(new Date(t));
+  }
+  return slots;
+}
+
 /**
  * Récupère les événements du calendrier Google pour une période donnée via l'API avancée.
  * @param {Date} dateDebut La date de début de la période.


### PR DESCRIPTION
## Summary
- add `getQuarterHourSlotsForWeek_` to generate 15-minute slots for a whole week
- confirm calendar logic no longer uses AM/PM branching

## Testing
- `npm test`
- `npm run test:clasp` *(fails: unknown option '--noninteractive')*

------
https://chatgpt.com/codex/tasks/task_e_68becd2f8d5883269afe860b426c212e