### PR TITLE
feat: support DOCS_PUBLIC_FOLDER_ID alias

### DIFF
--- a/Configuration_RequiredProps.gs
+++ b/Configuration_RequiredProps.gs
@@ -15,6 +15,7 @@ const REQUIRED_PROPS = Object.freeze([
   'ID_MODELE_FACTURE',
   'ID_DOSSIER_ARCHIVES',
   'ID_DOSSIER_TEMPORAIRE',
+  // Dossier Drive exposé publiquement (alias accepté: DOCS_PUBLIC_FOLDER_ID)
   'DOSSIER_PUBLIC_FOLDER_ID',
   'ID_DOCUMENT_CGV',
   'ELS_SHARED_SECRET'
@@ -27,6 +28,11 @@ const REQUIRED_PROPS = Object.freeze([
 function test_requiredProps() {
   const sp = PropertiesService.getScriptProperties();
   const missing = REQUIRED_PROPS.filter(k => {
+    if (k === 'DOSSIER_PUBLIC_FOLDER_ID') {
+      const v1 = sp.getProperty('DOSSIER_PUBLIC_FOLDER_ID');
+      const v2 = sp.getProperty('DOCS_PUBLIC_FOLDER_ID');
+      return (v1 === null || v1 === '') && (v2 === null || v2 === '');
+    }
     const v = sp.getProperty(k);
     return v === null || v === '';
   });

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Set the following keys in the Apps Script editor (File → Project properties �
 - `ID_MODELE_FACTURE` – modèle Google Docs pour générer les factures
 - `ID_DOSSIER_ARCHIVES` – dossier Drive d'archivage des factures
 - `ID_DOSSIER_TEMPORAIRE` – dossier Drive temporaire pour génération des PDF
+- `DOSSIER_PUBLIC_FOLDER_ID` – dossier Drive public (alias : `DOCS_PUBLIC_FOLDER_ID`)
 - `ID_FEUILLE_CALCUL` – feuille de calcul principale
 - `ID_CALENDRIER` – calendrier Google utilisé pour les créneaux
 - `ELS_SHARED_SECRET` – clé secrète pour signer les liens d'accès à l'espace client

--- a/Utilitaires.gs
+++ b/Utilitaires.gs
@@ -173,7 +173,15 @@ function include(nomFichier) {
  * @throws {Error} Si la propriété est absente.
  */
 function getSecret(name) {
-  const value = PropertiesService.getScriptProperties().getProperty(name);
+  const sp = PropertiesService.getScriptProperties();
+  let value = sp.getProperty(name);
+  if (value === null || value === '') {
+    if (name === 'DOSSIER_PUBLIC_FOLDER_ID') {
+      value = sp.getProperty('DOCS_PUBLIC_FOLDER_ID');
+    } else if (name === 'DOCS_PUBLIC_FOLDER_ID') {
+      value = sp.getProperty('DOSSIER_PUBLIC_FOLDER_ID');
+    }
+  }
   if (value === null || value === '') {
     throw new Error(`Propriété manquante: ${name}`);
   }


### PR DESCRIPTION
## Summary
- allow `DOCS_PUBLIC_FOLDER_ID` as alias for `DOSSIER_PUBLIC_FOLDER_ID`
- fallback in `getSecret` to handle the alias
- document the alias in README

## Testing
- `npm test`
- `npm run test:clasp` *(fails: unknown option '--noninteractive')*


------
https://chatgpt.com/codex/tasks/task_e_68c08e6194ac83268228fc81f0d3134f