### PR TITLE
feat: avertir si configuration incomplète

### DIFF
--- a/Admin_CSS.html
+++ b/Admin_CSS.html
@@ -9,6 +9,25 @@ body {
   color: var(--txt);
 }
 
+.alert {
+  background-color: var(--danger);
+  color: var(--txt);
+  padding: 15px 20px;
+  border-left: 4px solid var(--violet);
+  border-radius: var(--radius);
+  margin: 20px auto;
+  max-width: 900px;
+}
+
+.alert ul {
+  margin: 8px 0 0 20px;
+}
+
+.alert strong {
+  display: block;
+  margin-bottom: 4px;
+}
+
 /* --- MISE EN PAGE PRINCIPALE --- */
 #app-conteneur-principal {
   max-width: 900px;

--- a/Admin_Interface.html
+++ b/Admin_Interface.html
@@ -78,6 +78,8 @@
     <div class="spinner"></div>
   </div>
 
+  <div id="missing-props-banner" class="alert hidden" role="alert"></div>
+
   <div id="app-conteneur-principal">
     <header class="app-en-tete">
       <?!= include('Logo'); ?>

--- a/Admin_JS.html
+++ b/Admin_JS.html
@@ -34,11 +34,20 @@ document.addEventListener('DOMContentLoaded', () => {
     const contenuModale = document.getElementById('contenu-modale-wrapper');
     const btnFermerModale = document.getElementById('btn-fermer-modale');
     const caEnCours = document.getElementById('ca-en-cours');
+    const missingPropsBanner = document.getElementById('missing-props-banner');
 
     // --- Variables d'état ---
     let toutesLesReservationsAffichees = [];
     let tousLesClients = [];
     let vueActuelle = 'date'; // NOUVEAU: pour savoir quelle vue rafraîchir ('date' ou 'toutes')
+
+    google.script.run.withSuccessHandler(res => {
+        if (res && Array.isArray(res.missingProps) && res.missingProps.length > 0 && missingPropsBanner) {
+            const items = res.missingProps.map(p => `<li>${escapeHTML(p)}</li>`).join('');
+            renderHTML(missingPropsBanner, `<strong>Configuration manquante :</strong><ul>${items}</ul>`);
+            missingPropsBanner.classList.remove('hidden');
+        }
+    }).withFailureHandler(logError).checkSetup_ELS();
 
     /**
      * Initialise le tableau de bord.


### PR DESCRIPTION
## Summary
- add missing configuration banner in admin interface
- check setup on load and display missing properties list
- style alert with brand colors and role=alert

## Testing
- `npm test`
- `npm run test:clasp` *(fails: unknown option '--noninteractive')*

------
https://chatgpt.com/codex/tasks/task_e_68c08e651f8483268b006b2fdd692c63