### PR TITLE
feat: add admin slots PNG flag

### DIFF
--- a/Admin_Interface.html
+++ b/Admin_Interface.html
@@ -196,10 +196,12 @@
           <div class="form-col" id="contenu-modale-wrapper">
             <!-- … ton formulaire … -->
           </div>
+          <? if (ADMIN_SLOTS_PNG_ENABLED) { ?>
           <aside class="slots-sidebar" aria-label="Créneaux disponibles">
             <h4>Créneaux disponibles</h4>
             <div class="slots-row" id="slotsRow"></div>
           </aside>
+          <? } ?>
         </div>
       </div>
 

--- a/Admin_JS.html
+++ b/Admin_JS.html
@@ -28,7 +28,9 @@ function openModal() {
   if (modal) modal.hidden = false;
   const firstInput = modal?.querySelector('input, select, textarea, button');
   if (firstInput) firstInput.focus({ preventScroll: true });
+  <? if (ADMIN_SLOTS_PNG_ENABLED) { ?>
   google.script.run.withSuccessHandler(renderSlots).withFailureHandler(logError).obtenirStatutCreneaux();
+  <? } ?>
 }
 
 function closeModal() {
@@ -36,6 +38,7 @@ function closeModal() {
   const modal = document.getElementById('modale-action');
   if (modal) modal.hidden = true;
 }
+<? if (ADMIN_SLOTS_PNG_ENABLED) { ?>
 function renderSlots(slots){
   const row = document.getElementById('slotsRow');
   if(!row) return;
@@ -95,6 +98,7 @@ function markUrgentSlots(delayMin = 60) {
 }
 // Exemple : urgents dans l'heure
 // markUrgentSlots(60);
+<? } ?>
 
 document.addEventListener('DOMContentLoaded', () => {
     // --- Références aux éléments du DOM ---

--- a/Configuration.gs
+++ b/Configuration.gs
@@ -121,6 +121,9 @@ const CALENDAR_BAR_OPACITY_ENABLED = true;
 /** @const {boolean} Active la création optimiste des courses admin. */
 const ADMIN_OPTIMISTIC_CREATION_ENABLED = false;
 
+/** @const {boolean} Active la colonne de créneaux PNG dans la modale admin. */
+const ADMIN_SLOTS_PNG_ENABLED = false;
+
 /** @const {boolean} Vérifie la création d'événement et l'unicité des ID de réservation. */
 const RESERVATION_VERIFY_ENABLED = true;
 
@@ -211,7 +214,8 @@ const FLAGS = Object.freeze({
   elsUiThemingEnabled: ELS_UI_THEMING_ENABLED,
   pricingRulesV2Enabled: PRICING_RULES_V2_ENABLED,
   returnImpactsEstimatesEnabled: RETURN_IMPACTS_ESTIMATES_ENABLED,
-  adminOptimisticCreationEnabled: ADMIN_OPTIMISTIC_CREATION_ENABLED
+  adminOptimisticCreationEnabled: ADMIN_OPTIMISTIC_CREATION_ENABLED,
+  adminSlotsPngEnabled: ADMIN_SLOTS_PNG_ENABLED
 });
 
 


### PR DESCRIPTION
## Summary
- add `ADMIN_SLOTS_PNG_ENABLED` feature flag for admin slot PNG column
- show admin slot PNG column only when flag enabled
- guard slot rendering logic behind the new flag

## Testing
- `npm test`
- `npm run test:clasp` *(fails: unknown option '--noninteractive')*

------
https://chatgpt.com/codex/tasks/task_e_68c167f4101483269aaa82c0fdf4b81c